### PR TITLE
Add simmer simulation history

### DIFF
--- a/.github/workflows/bazel_tests.yml
+++ b/.github/workflows/bazel_tests.yml
@@ -26,6 +26,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: install-python-dependencies
+        run: python -m pip install beautifulsoup4 jinja2
       
       - name: install-bazelisk
         uses: vsco/bazelisk-action@master
@@ -35,4 +42,4 @@ jobs:
           os: 'linux'
 
       - name: run-bazel-checks
-        run: bazel test //:buildifier_test //tests:all //tests/vcs_filelist_validation:all
+        run: bazel test --test_output=errors //:buildifier_test //tests:all //tests/vcs_filelist_validation:all

--- a/.github/workflows/bazel_tests.yml
+++ b/.github/workflows/bazel_tests.yml
@@ -1,12 +1,31 @@
 name: Run Bazel Tests
-on: [push]
+
+on:
+  pull_request:
+    paths:
+      - ".bazelrc"
+      - ".github/workflows/**"
+      - "BUILD"
+      - "WORKSPACE"
+      - "**/*.bzl"
+      - "**/BUILD"
+      - "bin/**"
+      - "deps/**"
+      - "lib/**"
+      - "simulators/**"
+      - "tests/**"
+      - "vendors/**"
+      - "verilog/**"
+
 jobs:
   bazel-tests:
     name: Bazel Tests
     runs-on: ubuntu-latest
+    env:
+      USE_BAZEL_VERSION: "6.5.0"
     steps:
       - name: checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
       
       - name: install-bazelisk
         uses: vsco/bazelisk-action@master
@@ -15,5 +34,5 @@ jobs:
           bazel-install-path: './.local/bin'
           os: 'linux'
 
-      - name: run-buildifier-diff
-        run: bazel run //tests:buildifier_format_diff
+      - name: run-bazel-checks
+        run: bazel test //:buildifier_test //tests:all //tests/vcs_filelist_validation:all

--- a/.github/workflows/yapf_check.yml
+++ b/.github/workflows/yapf_check.yml
@@ -1,12 +1,43 @@
 name: YAPF Formatting Check
-on: [push]
+
+on:
+  pull_request:
+    paths:
+      - "**/*.py"
+
 jobs:
   formatting-check:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - name: Run YAPF python style checks
-        uses: AlexanderMelde/yapf-action@master
+      - uses: actions/checkout@v4
         with:
-          args: --diff --recursive --style env/.style.yapf
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Collect changed Python files
+        id: changed
+        shell: bash
+        run: |
+          mapfile -d '' files < <(git diff -z --name-only --diff-filter=ACMRT \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- '*.py')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "files=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\0' "${files[@]}" > changed-python-files
+          echo "files=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install YAPF
+        if: steps.changed.outputs.files == 'true'
+        run: python -m pip install yapf
+
+      - name: Run YAPF python style checks
+        if: steps.changed.outputs.files == 'true'
+        shell: bash
+        run: |
+          mapfile -d '' files < changed-python-files
+          python -m yapf --diff --style env/.style.yapf "${files[@]}"

--- a/.github/workflows/yapf_check.yml
+++ b/.github/workflows/yapf_check.yml
@@ -18,26 +18,13 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Collect changed Python files
-        id: changed
-        shell: bash
-        run: |
-          mapfile -d '' files < <(git diff -z --name-only --diff-filter=ACMRT \
-            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- '*.py')
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "files=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          printf '%s\0' "${files[@]}" > changed-python-files
-          echo "files=true" >> "$GITHUB_OUTPUT"
-
       - name: Install YAPF
-        if: steps.changed.outputs.files == 'true'
         run: python -m pip install yapf
 
       - name: Run YAPF python style checks
-        if: steps.changed.outputs.files == 'true'
         shell: bash
         run: |
-          mapfile -d '' files < changed-python-files
-          python -m yapf --diff --style env/.style.yapf "${files[@]}"
+          git diff -U0 --no-color \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- '*.py' \
+            | yapf-diff --style env/.style.yapf > yapf.patch
+          test ! -s yapf.patch || { cat yapf.patch; exit 1; }

--- a/bin/BUILD
+++ b/bin/BUILD
@@ -38,6 +38,7 @@ py_binary(
         "//lib:regression",
         "//lib:rv_utils",
         "//lib:runtime_options",
+        "//lib:simmer_results",
         "//lib/simulators:simulators",
         "//lib:regression_report",
     ],

--- a/bin/args_parse/common.py
+++ b/bin/args_parse/common.py
@@ -183,6 +183,12 @@ def add_regression_arguments(parser):
                         default=False,
                         action='store_true',
                         help='Print simmer phase/job runtime details for performance tuning.')
+    gregre.add_argument('--history', '--his',
+                        nargs='?',
+                        const=10,
+                        default=None,
+                        type=int,
+                        help='Print recent simmer simulation records. Defaults to 10 entries.')
     gregre.add_argument('--no-stdout',
                         default=False,
                         action='store_true',

--- a/bin/args_parse/common.py
+++ b/bin/args_parse/common.py
@@ -183,7 +183,8 @@ def add_regression_arguments(parser):
                         default=False,
                         action='store_true',
                         help='Print simmer phase/job runtime details for performance tuning.')
-    gregre.add_argument('--history', '--his',
+    gregre.add_argument('--history',
+                        '--his',
                         nargs='?',
                         const=10,
                         default=None,

--- a/bin/args_parse/parser.py
+++ b/bin/args_parse/parser.py
@@ -62,6 +62,8 @@ def parse_args(argv):
     options = parser.parse_args(argv)
     if options.jobs is not None and options.jobs < 1:
         parser.error("--jobs must be a positive integer.")
+    if options.history is not None and options.history < 1:
+        parser.error("--history must be a positive integer.")
     options.simulator_was_explicit = simulator_explicitly_requested(argv)
     options.xprop_was_explicit = argument_explicitly_requested(argv, '--xprop')
     options.timeout_was_explicit = argument_explicitly_requested(argv, '--timeout')

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -33,6 +33,7 @@ from lib import cmn_logging
 from lib import job_lib
 from lib import regression
 from lib import rv_utils
+from lib import simmer_results
 from lib.runtime_options import (
     format_sim_opts_dict,
     merge_test_runtime_sim_opts,
@@ -473,6 +474,7 @@ class VCompJob(Job):
         # --- Final Logging ---
         # log_level is determined by initial return code and potential warning failures
         log_level("%s vcomp %s in %s", self.name, self.jobstatus, self.job_dir)
+        simmer_results.record_compile_job(getattr(self.rcfg, "simmer_results_run", None), self)
 
         # Base class post_run might handle completion, but setting explicitly ensures it
         # Note: '_completed' isn't standard, jobstatus.completed is the way to check
@@ -672,6 +674,7 @@ class TestJob(Job):
                 ) from exc
         elif seed is None:
             seed = random.randint(0, 1 << (32 - 1)) # xrun is treating the seed as a signed integer
+        self.seed = seed
 
         # Using the timestamp as the name uniquifier is causing issues when trying to spawn many jobs at once
         # strdate = time.strftime("%Y_%m_%d_%H_%M_%S", time.localtime(time.time()))
@@ -906,6 +909,9 @@ class TestJob(Job):
         self.main_cmdline = '/usr/bin/env bash %s' % (testscript_path)
 
     def post_run(self):
+        options = self.rcfg.options
+        run_wave_script_path = None
+        abs_wave_path = None
         super(TestJob, self).post_run()
 
         # Parse file for duration
@@ -995,6 +1001,12 @@ class TestJob(Job):
             log.info(f"Run wave: {run_wave_script_path}")
 
         sys.stdout.flush()
+        simmer_results.record_test_job(
+            getattr(self.rcfg, "simmer_results_run", None),
+            self,
+            waves_script=run_wave_script_path,
+            waves_path=abs_wave_path,
+        )
 
         if self.rcfg.tidy and self.jobstatus.successful:
             log.debug("tidy=%s removing %s", self.rcfg.tidy, self.job_dir)
@@ -1131,6 +1143,13 @@ def main(rcfg, options):
             sys.exit(1)
         if options.seed is not None:
             rcfg.log.critical("--seed can only be used if a single test is run")
+    rcfg.simmer_results_run = None
+    if not options.no_run:
+        rcfg.simmer_results_run = simmer_results.create_run(
+            getattr(options, "simmer_argv", sys.argv),
+            rcfg,
+            total_tests,
+        )
 
     try:
         jm_opts = {
@@ -1213,8 +1232,18 @@ def main(rcfg, options):
             vso_finalize_merge_failed = True
             log.error("%s", exc)
 
-    rv_utils.print_summary(rcfg, vcomp_jobs, icfgs, jm, trd)
+    regression_log_path = rv_utils.print_summary(rcfg, vcomp_jobs, icfgs, jm, trd)
     rv_utils.print_simmer_profile(rcfg, jm)
+    if getattr(rcfg, "simmer_results_run", None) is not None:
+        simmer_results.finalize_run(
+            rcfg.simmer_results_run,
+            regression_log_path=regression_log_path,
+            vso_finalize_merge_failed=vso_finalize_merge_failed,
+        )
+        try:
+            simmer_results.save_run(rcfg.proj_dir, rcfg.simmer_results_run)
+        except OSError as exc:
+            log.error("Failed to write simmer results: %s", exc)
     # add category_stats for soc
     category_stats = None
     if options.category_cfg is not None:
@@ -1268,6 +1297,11 @@ def main(rcfg, options):
 
 if __name__ == '__main__':
     options = parse_args(sys.argv[1:])
+    if options.history is not None:
+        history_use_color = True if options.use_color else None
+        simmer_results.print_history(options.proj_dir, options.history, use_color=history_use_color)
+        sys.exit(0)
+    options.simmer_argv = sys.argv[:]
     verbosity = cmn_logging.DEBUG if options.tool_debug else cmn_logging.INFO
     log = cmn_logging.build_logger("sim", level=verbosity, use_color=options.use_color, filehandler="simmer.log")
     rcfg = regression.RegressionConfig(options, log)

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -1210,7 +1210,7 @@ def main(rcfg, options):
                 "merge simulator coverage databases",
                 lambda: simulator.run_report_coverage_merge(vcomp_jobs),
             )
-        
+
         report_header = rv_utils.get_report_header(rcfg)
         if report_header is not None and 'tag' in report_header:
             if '-' in report_header['tag']:

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -140,3 +140,47 @@ is going to Bazel setup, VCS compile, runtime simulation, or log checking.
 
 For quiet normal runs, avoid `--tool-debug`; it prints scheduler polling noise.
 
+## Simulation history
+
+Completed simulation runs are recorded in `.simmer_results.json` at the project
+root. The file is local run state and is intended for quick lookup of recent
+simulation outputs.
+
+Print the most recent 10 runs:
+
+```bash
+simmer --history
+simmer --his
+```
+
+Print a custom number of runs:
+
+```bash
+simmer --history 20
+simmer --his 20
+```
+
+Each entry includes the original `simmer` command, compile log, and result log.
+For a single test with wave dumping enabled, the history also shows the
+generated `run_waves.sh` path. For multi-test regressions, the result path is
+the regression log rather than every individual case log.
+
+Example:
+
+```text
+[1] 2026-07-09 15:03:04  FAILED  87/100 pass, 13 fail
+cmd:     simmer -t sys_tb:*@10
+compile: /sim/sys_tb/cmp.log
+result:  /sim/regression.log
+```
+
+Status words and pass/fail labels are colorized when output goes to a terminal.
+Use `--use-color` to force color output:
+
+```bash
+simmer --use-color --history
+```
+
+Runs that only discover tests, compile without running simulation, or fail
+before any simulation job starts are not recorded.
+

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -39,3 +39,8 @@ py_library(
     name = "runtime_options",
     srcs = ["runtime_options.py"],
 )
+
+py_library(
+    name = "simmer_results",
+    srcs = ["simmer_results.py"],
+)

--- a/lib/rv_utils.py
+++ b/lib/rv_utils.py
@@ -167,7 +167,7 @@ def print_summary(rcfg, vcomp_jobs, jm, trd):
                 for j in passed:
                     table_data.append(("", "", "", "", "", "", "", j.log_path if j.log_path else ''))
                     trd.append(("", "", "", "", "", "", "", j.log_path if j.log_path else ''))
-        
+
         if i != last:
             table_data.append(separator)
 
@@ -203,7 +203,7 @@ def print_summary(rcfg, vcomp_jobs, jm, trd):
             table_data[i] = ['-' * cw for cw in column_widths]
     table_data_formatted = [formatter.format(*i) for i in table_data]
     rcfg.log.summary("Job Results\n%s", "\n".join(table_data_formatted))
-    
+
     if total_tests > 1 and not rcfg.options.no_run:
         with open(regression_log_path, 'a') as file:
             formatted_string = "Job Results\n" + "\n".join(map(str, table_data_formatted))
@@ -214,7 +214,7 @@ def print_summary(rcfg, vcomp_jobs, jm, trd):
     table_data.append(("", "", "", str(total_passed), str(total_skipped), str(total_failed), str(total), ""))
     table_data_formatted = [formatter.format(*i) for i in table_data]
     rcfg.log.summary("Simulation Summary\n%s", "\n".join(table_data_formatted))
-    
+
     if total_tests > 1 and not rcfg.options.no_run:
         with open(regression_log_path, 'a') as file:
             formatted_string = "\n" + "Simulation Summary\n" + "\n".join(map(str, table_data_formatted))
@@ -310,7 +310,7 @@ def get_report_header(rcfg):
         if match:
             header['project_name'] = match.group(1)
         else:
-            print("Error: Invalid Git URL format or .git suffix missing.")                
+            print("Error: Invalid Git URL format or .git suffix missing.")
         header["branch"] = branch
         header['tag'] = tag_info
         header["revision"] = short_revision
@@ -376,7 +376,7 @@ def get_coverage_data(rcfg, vcomp_jobs):
                                 cells = [td.get_text(strip=True).replace('\u00a0', '') for td in row.find_all('td')]
                                 if 'Cumulative' in cells:
                                     cov[vcomp_name]['cc'] =  dict(zip(header, cells))
-        
+
             result = subprocess.run(['grep', '-rl', env_pattern, report_dir], capture_output=True, text=True)
             grep_files = result.stdout.splitlines()
             env_file = [f for f in grep_files if include in f]

--- a/lib/rv_utils.py
+++ b/lib/rv_utils.py
@@ -95,10 +95,11 @@ def print_summary(rcfg, vcomp_jobs, icfgs, jm, trd):
     :param trd: List to store test results data
     """
     trd.clear()
+    regression_log_path = None
     total_tests = sum([icfg.target for _, (icfgs, _) in rcfg.all_vcomp.items() for icfg in icfgs])
     if total_tests > 1:
         if not rcfg.options.no_run:
-            REGRESSION_LOG_PATH = create_regression_log_file(rcfg)
+            regression_log_path = create_regression_log_file(rcfg)
     else:
         if rcfg.options.report:
             current_time = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -205,7 +206,7 @@ def print_summary(rcfg, vcomp_jobs, icfgs, jm, trd):
     rcfg.log.summary("Job Results\n%s", "\n".join(table_data_formatted))
     
     if total_tests > 1 and not rcfg.options.no_run:
-        with open(REGRESSION_LOG_PATH, 'a') as file:
+        with open(regression_log_path, 'a') as file:
             formatted_string = "Job Results\n" + "\n".join(map(str, table_data_formatted))
             file.write(formatted_string)
 
@@ -216,9 +217,10 @@ def print_summary(rcfg, vcomp_jobs, icfgs, jm, trd):
     rcfg.log.summary("Simulation Summary\n%s", "\n".join(table_data_formatted))
     
     if total_tests > 1 and not rcfg.options.no_run:
-        with open(REGRESSION_LOG_PATH, 'a') as file:
+        with open(regression_log_path, 'a') as file:
             formatted_string = "\n" + "Simulation Summary\n" + "\n".join(map(str, table_data_formatted))
             file.write(formatted_string)
+    return regression_log_path
 
 
 def print_simmer_profile(rcfg, jm):

--- a/lib/simmer_results.py
+++ b/lib/simmer_results.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python
+"""Local simmer result history helpers."""
+
+import datetime
+import json
+import os
+import shlex
+import sys
+
+
+RESULTS_FILENAME = ".simmer_results.json"
+SCHEMA_VERSION = 1
+MAX_RUNS = 100
+COLOR_GREEN = "\033[0;32m"
+COLOR_RED = "\033[0;31m"
+COLOR_YELLOW = "\033[0;33m"
+COLOR_NC = "\033[0m"
+
+
+def results_path(project_dir):
+    return os.path.join(project_dir, RESULTS_FILENAME)
+
+
+def format_command(argv):
+    if not argv:
+        return "simmer"
+    display_argv = list(argv)
+    display_argv[0] = os.path.basename(display_argv[0]) or display_argv[0]
+    return " ".join(shlex.quote(str(arg)) for arg in display_argv)
+
+
+def _timestamp():
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _run_id():
+    return datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def create_run(argv, rcfg, planned_tests):
+    return {
+        "run_id": _run_id(),
+        "started_at": _timestamp(),
+        "finished_at": None,
+        "command": format_command(argv),
+        "argv": list(argv),
+        "project_dir": rcfg.proj_dir,
+        "regression_dir": rcfg.regression_dir,
+        "planned_tests": planned_tests,
+        "status": "RUNNING",
+        "regression_log": None,
+        "summary": {
+            "passed": 0,
+            "failed": 0,
+            "skipped": 0,
+            "total": planned_tests,
+        },
+        "compile": [],
+        "tests": [],
+    }
+
+
+def _upsert_by_key(items, key, value):
+    for index, item in enumerate(items):
+        if item.get(key) == value.get(key):
+            items[index] = value
+            return
+    items.append(value)
+
+
+def record_compile_job(run, vcomp_job):
+    if run is None:
+        return
+    compile_record = {
+        "bench": vcomp_job.name,
+        "vcomp_target": vcomp_job.bazel_vcomp_target,
+        "status": vcomp_job.jobstatus.name,
+        "compile_dir": vcomp_job.job_dir,
+        "cmp_log": vcomp_job.log_path,
+    }
+    _upsert_by_key(run["compile"], "vcomp_target", compile_record)
+
+
+def record_test_job(run, test_job, waves_script=None, waves_path=None):
+    if run is None:
+        return
+    waves_enabled = test_job.rcfg.options.waves is not None
+    waves = {"enabled": waves_enabled}
+    if waves_enabled:
+        waves.update({
+            "path": waves_path,
+            "run_script": waves_script,
+            "exists": bool(waves_path and os.path.exists(waves_path)),
+        })
+
+    run["tests"].append({
+        "bench": test_job.vcomper.name,
+        "test": test_job.name,
+        "target": test_job.target,
+        "vcomp_target": test_job.vcomper.bazel_vcomp_target,
+        "iteration": test_job.iteration,
+        "seed": getattr(test_job, "seed", None),
+        "status": test_job.jobstatus.name,
+        "duration_s": int(getattr(test_job, "duration_s", 0) or 0),
+        "compile_dir": test_job.vcomper.job_dir,
+        "sim_dir": test_job.job_dir,
+        "stdout_log": test_job._log_path,
+        "cmp_log": test_job.vcomper.log_path,
+        "waves": waves,
+        "error_message": getattr(test_job, "error_message", None),
+    })
+
+
+def finalize_run(run, regression_log_path=None, vso_finalize_merge_failed=False):
+    if run is None:
+        return
+    run["finished_at"] = _timestamp()
+    run["regression_log"] = regression_log_path
+
+    tests = run.get("tests", [])
+    planned_tests = int(run.get("planned_tests") or len(tests))
+    passed = sum(1 for test in tests if test.get("status") == "PASSED")
+    failed = sum(1 for test in tests if test.get("status") == "FAILED")
+    skipped = max(0, planned_tests - len(tests))
+
+    run["summary"] = {
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "total": planned_tests,
+    }
+
+    if tests:
+        if skipped:
+            run["status"] = "PARTIAL"
+        elif failed or vso_finalize_merge_failed:
+            run["status"] = "FAILED"
+        else:
+            run["status"] = "PASSED"
+        return
+
+    if any(item.get("status") == "FAILED" for item in run.get("compile", [])):
+        run["status"] = "COMPILE_FAILED"
+    else:
+        run["status"] = "NO_SIM_RUN"
+
+
+def _empty_store():
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "last_run": None,
+        "runs": [],
+    }
+
+
+def load_store(project_dir):
+    path = results_path(project_dir)
+    if not os.path.exists(path):
+        return _empty_store()
+    try:
+        with open(path, "r", encoding="utf-8") as filep:
+            store = json.load(filep)
+    except (OSError, json.JSONDecodeError):
+        return _empty_store()
+    if not isinstance(store, dict):
+        return _empty_store()
+    store.setdefault("schema_version", SCHEMA_VERSION)
+    store.setdefault("last_run", None)
+    store.setdefault("runs", [])
+    return store
+
+
+def save_run(project_dir, run, max_runs=MAX_RUNS):
+    if not run.get("tests"):
+        return
+    store = load_store(project_dir)
+    runs = [item for item in store.get("runs", []) if item.get("run_id") != run.get("run_id")]
+    runs.append(run)
+    runs = runs[-max_runs:]
+    store = {
+        "schema_version": SCHEMA_VERSION,
+        "last_run": run,
+        "runs": runs,
+    }
+    path = results_path(project_dir)
+    temp_path = "{}.{}.tmp".format(path, os.getpid())
+    with open(temp_path, "w", encoding="utf-8") as filep:
+        json.dump(store, filep, indent=2)
+        filep.write("\n")
+    os.replace(temp_path, path)
+
+
+def _select_compile_log(run):
+    tests = run.get("tests", [])
+    failed_tests = [test for test in tests if test.get("status") == "FAILED"]
+    if failed_tests and failed_tests[0].get("cmp_log"):
+        return failed_tests[0]["cmp_log"]
+    if tests and tests[0].get("cmp_log"):
+        return tests[0]["cmp_log"]
+    compile_records = run.get("compile", [])
+    if compile_records:
+        return compile_records[0].get("cmp_log") or "-"
+    return "-"
+
+
+def _select_result_log(run):
+    tests = run.get("tests", [])
+    if not tests:
+        return "-"
+    if int(run.get("planned_tests") or len(tests)) > 1:
+        return run.get("regression_log") or "-"
+    return tests[0].get("stdout_log") or "-"
+
+
+def _select_waves_script(run):
+    tests = run.get("tests", [])
+    if int(run.get("planned_tests") or len(tests)) != 1 or not tests:
+        return None
+    waves = tests[0].get("waves", {})
+    return waves.get("run_script") if waves.get("enabled") else "-"
+
+
+def _color_word(word, color, use_color):
+    if not use_color:
+        return word
+    return "{}{}{}".format(color, word, COLOR_NC)
+
+
+def _format_pass_summary(run, use_color=False):
+    summary = run.get("summary", {})
+    passed = summary.get("passed", 0)
+    failed = summary.get("failed", 0)
+    total = summary.get("total", 0)
+    pass_text = _color_word("pass", COLOR_GREEN, use_color)
+    if failed:
+        fail_text = _color_word("fail", COLOR_RED, use_color)
+        return "{}/{} {}, {} {}".format(passed, total, pass_text, failed, fail_text)
+    return "{}/{} {}".format(passed, total, pass_text)
+
+
+def _resolve_use_color(use_color):
+    if use_color is None:
+        return sys.stdout.isatty()
+    return use_color
+
+
+def _color_status(status, use_color):
+    if not use_color:
+        return status
+    if status == "PASSED":
+        return "{}{}{}".format(COLOR_GREEN, status, COLOR_NC)
+    if status == "FAILED":
+        return "{}{}{}".format(COLOR_RED, status, COLOR_NC)
+    if status == "PARTIAL":
+        return "{}{}{}".format(COLOR_YELLOW, status, COLOR_NC)
+    return status
+
+
+def format_history(project_dir, count, use_color=None):
+    use_color = _resolve_use_color(use_color)
+    store = load_store(project_dir)
+    runs = [run for run in store.get("runs", []) if run.get("tests")]
+    if not runs:
+        return "No simmer history found."
+
+    lines = []
+    recent_runs = list(reversed(runs))[:count]
+    for index, run in enumerate(recent_runs, start=1):
+        if lines:
+            lines.append("")
+        lines.append("[{}] {}  {}  {}".format(
+            index,
+            run.get("finished_at") or run.get("started_at") or "-",
+            _color_status(run.get("status", "-"), use_color),
+            _format_pass_summary(run, use_color=use_color),
+        ))
+        lines.append("cmd:     {}".format(run.get("command") or "-"))
+        lines.append("compile: {}".format(_select_compile_log(run)))
+        lines.append("result:  {}".format(_select_result_log(run)))
+        waves_script = _select_waves_script(run)
+        if waves_script is not None:
+            lines.append("waves:   {}".format(waves_script or "-"))
+    return "\n".join(lines)
+
+
+def print_history(project_dir, count, use_color=None):
+    print(format_history(project_dir, count, use_color=use_color))

--- a/lib/simmer_results.py
+++ b/lib/simmer_results.py
@@ -7,7 +7,6 @@ import os
 import shlex
 import sys
 
-
 RESULTS_FILENAME = ".simmer_results.json"
 SCHEMA_VERSION = 1
 MAX_RUNS = 100


### PR DESCRIPTION
## Summary

- record completed simulations in `.simmer_results.json` at the project root
- add `simmer --history` and `simmer --his` with configurable result count and colored pass/fail output
- include original command, compile log, result or regression log, and single-test waveform script paths
- skip discover-only runs, compile failures, and runs where simulation never starts
- document the simulation history workflow

## Validation

- `python -m compileall -q bin lib tests`
- `python tests/check_test_test.py`
- `python tests/job_manager_launch_test.py`
- `python tests/regression_discovery_test.py`
- `python tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py`
- verified `--history`, `--his`, positive-count validation, ANSI status colors, and that history queries do not create the results file

No third-party Python dependencies were added.