### PR TITLE
Improve simmer and Bazel performance

### DIFF
--- a/bin/args_parse/common.py
+++ b/bin/args_parse/common.py
@@ -178,7 +178,8 @@ def add_regression_arguments(parser):
     gregre.add_argument('--jobs',
                         type=int,
                         default=None,
-                        help='Maximum concurrent compile/simulation jobs. Defaults to the host CPU count.')
+                        help=('Maximum concurrent compile/simulation jobs. Defaults to the host CPU count, '
+                              'adjusted for VCS FGP or Xcelium MCE threads.'))
     gregre.add_argument('--simmer-profile',
                         default=False,
                         action='store_true',

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -198,7 +198,16 @@ def get_active_job_limit(options, rcfg):
     if options.gui:
         return 1
 
-    requested_jobs = options.jobs if options.jobs is not None else (os.cpu_count() or 1)
+    if options.jobs is not None:
+        requested_jobs = options.jobs
+    else:
+        cpu_count = os.cpu_count() or 1
+        threads_per_sim = 1
+        if options.simulator == "VCS" and options.fgp is not None:
+            threads_per_sim = options.fgp
+        elif options.simulator == "XRUN" and options.mce:
+            threads_per_sim = options.mce_sim_count or cpu_count
+        requested_jobs = max(1, cpu_count // threads_per_sim)
     return max(1, min(total_tests, requested_jobs))
 
 
@@ -659,7 +668,7 @@ class TestJob(Job):
         sim_opts = self.simulator.generate_sim_options(self, seed)
 
         sockets = []
-        runtime_options = self.btcj.dynamic_args()
+        runtime_options = self.btcj.dynamic_args(self.target)
         dynamic_simulator = runtime_options['simulator']
         if dynamic_simulator != self.simulator.get_name().upper():
             raise ValueError(
@@ -1062,12 +1071,11 @@ def main(rcfg, options):
 
         tests = []
         icfgs = []
+        btcj = job_lib.BazelTestCfgJob(rcfg, test_list.keys(), vcomper)
+        btcj_jobs.append(btcj)
         for test, iterations in test_list.items():
             icfg = rv_utils.IterationCfg(iterations)
             icfgs.append(icfg)
-
-            btcj = job_lib.BazelTestCfgJob(rcfg, test, vcomper)
-            btcj_jobs.append(btcj)
 
             # Create TestJob with simulator
             t = TestJob(rcfg, test, vcomper=vcomper, icfg=icfg, btcj=btcj, simulator=simulator)
@@ -1216,11 +1224,19 @@ def main(rcfg, options):
             if '-' in report_header['tag']:
                 report_header['tag'] = ''
         rrt = regression_report.RegressionReport(rcfg, jinja2_env, webroot_path)
-        report_lock_path = os.path.join(webroot_path, "regression_report.lock")
-        with open(report_lock_path, "w") as report_lock:
+        report_root = os.path.join(webroot_path, "regression_report")
+        project_lock_path = os.path.join(report_root, ".{}.lock".format(report_header['project_name']))
+        index_lock_path = os.path.join(report_root, ".index.lock")
+        os.makedirs(report_root, exist_ok=True)
+        rrt.prepare(report_header, trd, rv_utils.get_coverage_data(rcfg, vcomp_jobs), category_stats)
+        with open(index_lock_path, "w") as report_lock:
             import fcntl
             fcntl.flock(report_lock, fcntl.LOCK_EX)
-            rrt.run(report_header, trd, rv_utils.get_coverage_data(rcfg, vcomp_jobs), category_stats)
+            rrt.render_home_page()
+            rrt.render_bench_page()
+        with open(project_lock_path, "w") as report_lock:
+            fcntl.flock(report_lock, fcntl.LOCK_EX)
+            rrt.render_regression_page()
 
     rv_utils.print_simmer_profile(rcfg, jm)
 
@@ -1231,7 +1247,6 @@ def main(rcfg, options):
         #num_failed = sum(1 for j in test_jobs_list if j.jobstatus and not j.jobstatus.successful)
         #failures[bench] = num_failed
         if options.report:
-            rrt.change_permissions_recursively(os.path.join(webroot_path, "regression_report", report_header['project_name'], bench.split(":")[1]))
             log.info("Report at: http://dv-sh.rd.lgt.ai/regression_report/{0}/{1}".format(report_header['project_name'], bench.split(":")[1]))
 
     for message in getattr(rcfg, "deferred_messages", []):

--- a/lib/job_lib.py
+++ b/lib/job_lib.py
@@ -547,10 +547,11 @@ class BazelTBJob(Job):
         return 'Bazel("{}")'.format(self.bazel_target)
 
 class BazelTestCfgJob(Job):
-    """Bazel build for a testcfg only needs to be run once per test cfg, not per iteration. So split it out into its own job"""
+    """Build all selected test configs for one vcomp in a single Bazel invocation."""
 
-    def __init__(self, rcfg, target, vcomper):
-        self.bazel_target = target
+    def __init__(self, rcfg, targets, vcomper):
+        self.bazel_targets = [targets] if isinstance(targets, str) else list(targets)
+        self.bazel_target = self.bazel_targets[0]
         super(BazelTestCfgJob, self).__init__(rcfg, self)
         self.vcomper = vcomper
         if vcomper:
@@ -558,9 +559,9 @@ class BazelTestCfgJob(Job):
 
         self.job_dir = self.vcomper.job_dir # Don't actually need a dir, but jobrunner/manager want it defined
         if self.rcfg.options.no_bazel:
-            self.main_cmdline = "echo \"Bypassing {} due to --no-bazel\"".format(self.bazel_target)
+            self.main_cmdline = "echo \"Bypassing test cfg build due to --no-bazel\""
         else:
-            self.main_cmdline = "bazel build {}".format(self.bazel_target)
+            self.main_cmdline = "bazel build {}".format(" ".join(self.bazel_targets))
 
     def post_run(self):
         super(BazelTestCfgJob, self).post_run()
@@ -570,9 +571,9 @@ class BazelTestCfgJob(Job):
             self.jobstatus = JobStatus.FAILED
             self.log.error("%s failed. Log in %s", self, os.path.join(self.job_dir, "stderr.log"))
 
-    def dynamic_args(self):
+    def dynamic_args(self, target=None):
         """Additional arugmuents to specific to each simulation"""
-        path, target = self.bazel_target.split(":")
+        path, target = (target or self.bazel_target).split(":")
         path_to_dynamic_args_files = os.path.join(self.rcfg.proj_dir, "bazel-bin", path[2:],
                                                   "{}_dynamic_args.py".format(target))
         with open(path_to_dynamic_args_files, 'r') as filep:
@@ -581,4 +582,4 @@ class BazelTestCfgJob(Job):
         return normalize_test_runtime_options(dynamic_args)
 
     def __repr__(self):
-        return 'Bazel("{}")'.format(self.bazel_target)
+        return 'Bazel({} test cfgs)'.format(len(self.bazel_targets))

--- a/lib/regression.py
+++ b/lib/regression.py
@@ -108,7 +108,7 @@ class RegressionConfig():
         """
         if not cfg_path:
             cfg_path = os.path.join(self.proj_dir, "category_config.json")
-        
+
         self.category_total_cases = rv_utils.load_category_total_cases(cfg_path)
         self.log.info(f"Loaded subsystem config with tags: {self.category_total_cases}")
 
@@ -200,6 +200,20 @@ class RegressionConfig():
         return all(os.path.exists(self._cache_path(filename)) for filename in DISCOVERY_CACHE_FILES)
 
     def _iter_discovery_dependency_paths(self):
+        result = subprocess.run(
+            ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+            cwd=self.proj_dir,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            for relative_path in result.stdout.splitlines():
+                filename = os.path.basename(relative_path)
+                if filename in ("BUILD", "BUILD.bazel") or filename.endswith(".bzl"):
+                    yield os.path.join(self.proj_dir, os.path.normpath(relative_path))
+            return
+
         for root, dirs, files in os.walk(self.proj_dir):
             dirs[:] = [
                 directory for directory in dirs

--- a/lib/regression_report.py
+++ b/lib/regression_report.py
@@ -44,7 +44,7 @@ class RegressionReport():
         self.project_info = {}
 
         # category info
-        self.category_stats = {} 
+        self.category_stats = {}
         self.processed_category_stats = []
 
     def process_trd(self, trd):
@@ -93,109 +93,6 @@ class RegressionReport():
                                 "" if failed == 0 else str(failed), "" if total == 0 else str(total),
                                 f"{passed / total * 100:.2f}", "", ""])
 
-    def update_past_report_page(self, phtml, rlist, prlist, cclist, cflist, ori_rlist, ori_prlist):
-        """
-        Update 'Past Result' part of regression report page
-        """
-
-        # Reverser for date order
-        rlist.reverse()
-        prlist.reverse()
-        cclist.reverse()
-        cflist.reverse()
-
-        if len(rlist) > 0:
-            # new page index
-            page_info = [f'                  <li><a href="{r}.html">{r}_{pr}%_{cc}_{cf}</a></li>\n' for r, pr, cc, cf in zip(rlist, prlist, cclist, cflist)]
-            chart_info = [f'      const labels = {ori_rlist};\n      const data0 = {ori_prlist}\n']
-
-            for pr in rlist:
-                start_index_0 = None
-                end_index_0 = None
-                start_index_1 = None
-                end_index_1 = None
-                with open(phtml + '/' + pr + '.html', 'r', encoding='utf-8') as f:
-                    lines = f.readlines()
-                for i, line in enumerate(lines):
-                    if line.strip() == "<!-- update past result -->":
-                        if start_index_0 is None:
-                            start_index_0 = i
-                        else:
-                            end_index_0 = i
-                    if line.strip() == "<!-- update chart -->":
-                        if start_index_1 is None:
-                            start_index_1 = i
-                        else:
-                            end_index_1 = i
-                            break
-                # new lines
-                updated_lines = (
-                    lines[:start_index_0 + 1] +  # before past result comment
-                    page_info +                # new lines
-                    lines[end_index_0:start_index_1 + 1] + # after past result comment
-                    chart_info +               # new lines
-                    lines[end_index_1:]        # after chart comment
-                )
-                # write back to html
-                with open(phtml + '/' + pr + '.html', 'w', encoding='utf-8') as file:
-                    file.writelines(updated_lines)
-
-    def update_all_tb_navigation(self, bpath):
-        navigation_info = [f'                <li class="toctree-l2"><a class="reference internal" href="../{b}/index.html">{b}</a></li>\n' for b in self.project_info[self.proj_name]]
-
-        ppath = os.path.dirname(bpath)
-        for b in self.project_info[self.proj_name]:
-            b_dir = os.path.join(ppath, b)
-            if not os.path.isdir(b_dir):
-                continue
-
-            for rh in os.listdir(b_dir):
-                if not rh.endswith('.html'):
-                    continue
-
-                rp = os.path.join(b_dir, rh)
-
-                with open(rp, 'r', encoding='utf-8') as f:
-                    lines = f.readlines()
-
-                start_index = None
-                end_index = None
-                for i, line in enumerate(lines):
-                    if line.strip() == "<!-- update navigation -->":
-                        if start_index is None:
-                            start_index = i
-                        else:
-                            end_index = i
-                            break
-
-                if start_index is None or end_index is None:
-                    continue
-
-                updated_lines = (
-                    lines[:start_index + 1] +
-                    navigation_info +
-                    lines[end_index:]
-                )
-
-                with open(rp, 'w', encoding='utf-8') as f:
-                    f.writelines(updated_lines)
-
-    def change_permissions_recursively(self, bpath):
-        for root, dirs, files in os.walk(bpath):
-            try:
-                os.chmod(root, 0o777)
-            except PermissionError as e:
-                self.rcfg.log.info(f"P Error!!! Cannot chmod dir {root}: {e}")
-            except Exception as e:
-                self.rcfg.log.info(f"E Error!!! Cannot chmod dir {root}: {e}")
-            for file in files:
-                try:
-                    os.chmod(os.path.join(root, file), 0o777)
-                except PermissionError as e:
-                    self.rcfg.log.info(f"P Error!!! Cannot chmod dir {root}/{file}: {e}")
-                except Exception as e:
-                    self.rcfg.log.info(f"E Error!!! Cannot chmod dir {root}/{file}: {e}")
-
     def process_category_stats(self):
         """
         Process category statistics (strict mode) into template-friendly format
@@ -217,28 +114,30 @@ class RegressionReport():
 
             # Append processed data (match table columns in template)
             self.processed_category_stats.append([
-                category,          # name（like module_func_reset、soc_path_ddr）
-                str(total),        # total case number
-                str(executed),     # finished case number
-                completion_rate,   # rate of completion
-                str(passed),       # pass rate
-                pass_rate          
+                category, # name（like module_func_reset、soc_path_ddr）
+                str(total), # total case number
+                str(executed), # finished case number
+                completion_rate, # rate of completion
+                str(passed), # pass rate
+                pass_rate
             ])
 
     def run(self, header, trd, cov, category_stats):
         """
         API for simmer to create report page
         """
+        self.prepare(header, trd, cov, category_stats)
+        self.render_home_page()
+        self.render_bench_page()
+        self.render_regression_page()
+
+    def prepare(self, header, trd, cov, category_stats):
         self.header = header
         self.cov = cov
         self.category_stats = category_stats
         self.process_trd(trd)
         self.process_category_stats()
         self.proj_name = self.header["project_name"]
-        # Create html
-        self.render_home_page()
-        self.render_bench_page()
-        self.render_regression_page()
 
     def render_home_page(self):
         """
@@ -264,7 +163,7 @@ class RegressionReport():
         rendered_html = self.HOME_TEMPLATE.render(
             project=self.project_info,
         )
-        
+
         # Write html
         with open(html_file_path, 'w', encoding='utf-8') as f:
             f.write(rendered_html)
@@ -293,7 +192,7 @@ class RegressionReport():
             project_name=self.header["project_name"],
             project=self.project_info,
         )
-        
+
         # Write html
         with open(html_file_path, 'w', encoding='utf-8') as f:
             f.write(rendered_html)
@@ -391,11 +290,6 @@ class RegressionReport():
             cov_code_list = [regressions[ts]['cov_func'] for ts in remain_list if ts in regressions.keys()]
             cov_func_list = [regressions[ts]['cov_func'] for ts in remain_list if ts in regressions.keys()]
 
-            # Update old regression report page
-            self.update_past_report_page(bench_path, 
-                                        remain_list[:-1], passrate_list[:-1], cov_code_list[:-1], cov_func_list[:-1],
-                                        remain_list, passrate_list) 
-
             # Render
             rendered_html = self.REGRESSION_REPORT_TEMPLATE.render(
                 header=self.header,
@@ -420,7 +314,3 @@ class RegressionReport():
             # Update regressions json
             with open(json_file_path, 'w', encoding='utf-8') as f:
                 json.dump(regressions, f, ensure_ascii=False, indent=4)
-
-        #self.rcfg.log.summary("bench path is {}".format(bench_path))
-        self.update_all_tb_navigation(bench_path)
-        #self.change_permissions_recursively(bench_path)

--- a/lib/simmer_results.py
+++ b/lib/simmer_results.py
@@ -196,6 +196,10 @@ def load_store(project_dir):
 def save_run(project_dir, run, max_runs=MAX_RUNS):
     if not run.get("tests"):
         return
+    stored_run = dict(run)
+    if int(run.get("planned_tests") or len(run["tests"])) > 1 and len(run["tests"]) > 1:
+        representative = next((test for test in run["tests"] if test.get("status") == "FAILED"), run["tests"][0])
+        stored_run["tests"] = [representative]
     path = results_path(project_dir)
     with _store_lock(path):
         try:
@@ -205,11 +209,11 @@ def save_run(project_dir, run, max_runs=MAX_RUNS):
             os.replace(path, corrupt_path)
             print("Warning: moved invalid simmer history to {}".format(corrupt_path), file=sys.stderr)
             store = _empty_store()
-        runs = [item for item in store.get("runs", []) if item.get("run_id") != run.get("run_id")]
-        runs.append(run)
+        runs = [item for item in store.get("runs", []) if item.get("run_id") != stored_run.get("run_id")]
+        runs.append(stored_run)
         store = {
             "schema_version": SCHEMA_VERSION,
-            "last_run": run,
+            "last_run": stored_run,
             "runs": runs[-max_runs:],
         }
         temp_path = "{}.{}.{}.tmp".format(path, os.getpid(), uuid.uuid4().hex)

--- a/tests/job_manager_launch_test.py
+++ b/tests/job_manager_launch_test.py
@@ -102,6 +102,23 @@ class JobManagerLaunchTest(unittest.TestCase):
         self.assertIn("--no-compile/--no-bazel", tb_job.main_cmdline)
         self.assertIn("--no-bazel", cfg_job.main_cmdline)
 
+    def test_test_cfg_job_batches_targets_and_reads_each_dynamic_args_file(self):
+        log = _Logger()
+        rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1, no_bazel=False), log=log, proj_dir="/repo")
+        vcomper = SimpleNamespace(
+            job_dir="vcomp_dir",
+            _children=[],
+            add_dependency=lambda _job: None,
+            increase_priority=lambda _priority: None,
+        )
+        job = BazelTestCfgJob(rcfg, ["//pkg/tests:first", "//pkg/tests:second"], vcomper)
+
+        self.assertEqual("bazel build //pkg/tests:first //pkg/tests:second", job.main_cmdline)
+        with mock.patch("builtins.open", mock.mock_open(read_data="{'simulator': 'VCS'}")) as open_file:
+            job.dynamic_args("//pkg/tests:second")
+        open_file.assert_called_once_with(os.path.join("/repo", "bazel-bin", "pkg/tests", "second_dynamic_args.py"),
+                                          'r')
+
     def test_add_job_wakes_idle_scheduler(self):
         log = _Logger()
         manager = JobManager({"idle_print_seconds": 60, "quit_count": 1}, log)

--- a/tests/regression_discovery_test.py
+++ b/tests/regression_discovery_test.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 from lib.regression import RegressionConfig
 
@@ -83,6 +84,18 @@ class RegressionDiscoveryTest(unittest.TestCase):
         newer_time = cache_time + 10
         os.utime(build_file, (newer_time, newer_time))
         self.assertFalse(config._discovery_cache_is_fresh())
+
+    @mock.patch("lib.regression.os.walk", side_effect=AssertionError("walk should not run"))
+    @mock.patch("lib.regression.subprocess.run")
+    def test_cache_uses_git_file_index_when_available(self, run, _walk):
+        proj_dir = Path(tempfile.mkdtemp())
+        run.return_value = SimpleNamespace(returncode=0, stdout="pkg/BUILD\npkg/file.py\nrules/tool.bzl\n")
+        config = self._config(proj_dir)
+
+        self.assertEqual(
+            [str(proj_dir / "pkg/BUILD"), str(proj_dir / "rules/tool.bzl")],
+            list(config._iter_discovery_dependency_paths()),
+        )
 
     def test_requested_bench_query_is_scoped(self):
         config = self._config(Path(tempfile.mkdtemp()))

--- a/tests/simmer_results_test.py
+++ b/tests/simmer_results_test.py
@@ -74,6 +74,31 @@ class SimmerResultsTest(unittest.TestCase):
         self.assertEqual("FAILED", run["status"])
         self.assertEqual(1, run["summary"]["skipped"])
 
+    def test_multi_test_history_keeps_summary_and_one_representative_test(self):
+        run = self._completed_run()
+        run["planned_tests"] = 3
+        run["tests"] = [
+            {
+                "status": "PASSED",
+                "stdout_log": "pass.log"
+            },
+            {
+                "status": "FAILED",
+                "stdout_log": "fail.log"
+            },
+            {
+                "status": "PASSED",
+                "stdout_log": "pass2.log"
+            },
+        ]
+        run["summary"] = {"passed": 2, "failed": 1, "skipped": 0, "total": 3}
+
+        simmer_results.save_run(self.project_dir, run)
+
+        stored = simmer_results.load_store(self.project_dir)["last_run"]
+        self.assertEqual(run["summary"], stored["summary"])
+        self.assertEqual(["fail.log"], [test["stdout_log"] for test in stored["tests"]])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/verilog/private/dv.bzl
+++ b/verilog/private/dv.bzl
@@ -403,13 +403,13 @@ def _verilog_dv_library_impl(ctx):
     trans_flists = get_transitive_srcs([out], ctx.attr.deps, VerilogInfo, "transitive_flists", allow_other_outputs = False)
     trans_dpi = get_transitive_srcs(all_sos, ctx.attr.deps, VerilogInfo, "transitive_dpi", allow_other_outputs = False)
 
-    all_files = depset(trans_srcs.to_list() + trans_flists.to_list())
+    all_files = depset(transitive = [trans_srcs, trans_flists])
 
     return [
         VerilogInfo(transitive_sources = trans_srcs, transitive_flists = trans_flists, transitive_dpi = trans_dpi),
         DefaultInfo(
             files = all_files,
-            runfiles = ctx.runfiles(files = trans_srcs.to_list() + trans_flists.to_list()),
+            runfiles = ctx.runfiles(transitive_files = all_files),
         ),
     ]
 
@@ -603,13 +603,9 @@ def _verilog_dv_tb_impl(ctx):
     return [
         DefaultInfo(
             files = all_files,
-            runfiles = ctx.runfiles(files =
-                trans_srcs.to_list() +
-                trans_flists.to_list() +
-                out_deps.to_list() +
-                ctx.files.ccf +
-                ctx.files.extra_runfiles +
-                [runtime_template]
+            runfiles = ctx.runfiles(
+                files = ctx.files.ccf + ctx.files.extra_runfiles + [runtime_template],
+                transitive_files = all_files,
             ),
         ),
         DVTBInfo(

--- a/verilog/private/rtl.bzl
+++ b/verilog/private/rtl.bzl
@@ -184,10 +184,9 @@ def _verilog_rtl_library_impl(ctx):
     trans_flists = get_transitive_srcs([ctx.outputs.flist], ctx.attr.deps, VerilogInfo, "transitive_flists", allow_other_outputs = False)
     trans_dpi = get_transitive_srcs([], ctx.attr.deps, VerilogInfo, "transitive_dpi", allow_other_outputs = False)
 
-    runfiles_list = trans_srcs.to_list() + trans_flists.to_list() + trans_dpi.to_list()
-    runfiles = ctx.runfiles(files = runfiles_list)
+    runfiles = ctx.runfiles(transitive_files = depset(transitive = [trans_srcs, trans_flists, trans_dpi]))
 
-    all_files = depset(trans_srcs.to_list() + trans_flists.to_list())
+    all_files = depset(transitive = [trans_srcs, trans_flists])
 
     return [
         ShellInfo(

--- a/verilog/private/verilog.bzl
+++ b/verilog/private/verilog.bzl
@@ -81,16 +81,15 @@ def flists_to_arguments(deps, provider, field, prefix, separator = "", tool_name
     # Emit Bazel short_path entries so generated filelists stay rooted at the
     # runfiles tree, e.g. hw/... and external/..., instead of machine-specific
     # absolute paths or fragile ../ relative traversals.
-    trans = []
+    transitive = []
     for dep in deps:
         if provider in dep:
-            trans.extend(getattr(dep[provider], field).to_list())
+            transitive.append(getattr(dep[provider], field))
 
         # else:
         #     trans.extend(dep[DefaultInfo].files.to_list())
 
-    trans_depset = depset(trans)
-    trans = trans_depset.to_list()
+    trans = depset(transitive = transitive).to_list()
 
     if tool_name == "vcs":
         formatted_args = []
@@ -107,7 +106,6 @@ def flists_to_arguments(deps, provider, field, prefix, separator = "", tool_name
 
 def _verilog_test_impl(ctx):
     trans_srcs = get_transitive_srcs([], ctx.attr.shells + ctx.attr.deps, VerilogInfo, "transitive_sources")
-    srcs_list = trans_srcs.to_list()
     flists = get_transitive_srcs([], ctx.attr.shells + ctx.attr.deps, VerilogInfo, "transitive_flists")
     flists_list = flists.to_list()
 
@@ -141,7 +139,10 @@ def _verilog_test_impl(ctx):
     else:
         tool_runfiles = depset([])
 
-    runfiles = ctx.runfiles(files = flists_list + srcs_list + ctx.files.data, transitive_files = tool_runfiles)
+    runfiles = ctx.runfiles(
+        files = ctx.files.data,
+        transitive_files = depset(transitive = [trans_srcs, flists, tool_runfiles]),
+    )
 
     # runfiles = ctx.runfiles(files = flists_list + srcs_list)
     return [DefaultInfo(


### PR DESCRIPTION
## Summary
- batch selected test-config targets into one Bazel build per vcomp
- account for VCS FGP and Xcelium MCE threads in default job concurrency
- make regression reports incremental and shorten shared NFS lock scope
- preserve transitive depsets for Bazel analysis/runfiles
- use Git file indexing for discovery freshness and compact multi-test history

## Validation
- py -3 -m unittest tests.job_manager_launch_test tests.regression_discovery_test tests.simmer_results_test
- bazel test --test_output=errors //:buildifier_test //tests:all //tests/vcs_filelist_validation:all
- PR-diff YAPF check