### PR TITLE
Load category config only when enabled

### DIFF
--- a/bin/args_parse/common.py
+++ b/bin/args_parse/common.py
@@ -206,6 +206,7 @@ def add_regression_arguments(parser):
     gregre.add_argument('--category-cfg',
                         type=str,
                         nargs='?',
+                        const='',
                         default=None,
                         help="Path to category configuration JSON file (default: proj_dir/category_config.json)")
 

--- a/lib/regression.py
+++ b/lib/regression.py
@@ -54,7 +54,8 @@ class RegressionConfig():
 
         # Subsystem configuration (with tag associations)
         self.category_total_cases = {}
-        self.load_category_config(options.category_cfg)
+        if options.category_cfg is not None:
+            self.load_category_config(options.category_cfg)
 
         self.use_cached_discovery = self._profile_step(
             "discovery_cache_check",
@@ -104,7 +105,7 @@ class RegressionConfig():
     def load_category_config(self, cfg_path: str = None):
         """
         Load subsystem configuration with tag associations
-        Priority: specified path > project dir > default config
+        Use the specified path, or the project default when the flag has no value.
         """
         if not cfg_path:
             cfg_path = os.path.join(self.proj_dir, "category_config.json")

--- a/tests/regression_discovery_test.py
+++ b/tests/regression_discovery_test.py
@@ -177,15 +177,15 @@ class RegressionDiscoveryTest(unittest.TestCase):
         from lib import regression as regression_module
 
         original_calc = regression_module.rv_utils.calc_simresults_location
-        original_category = regression_module.rv_utils.load_category_total_cases
         regression_module.rv_utils.calc_simresults_location = lambda _proj_dir: str(results_dir)
-        regression_module.rv_utils.load_category_total_cases = lambda _cfg_path: {}
-        try:
-            config = RegressionConfig(options, _Log())
-        finally:
-            regression_module.rv_utils.calc_simresults_location = original_calc
-            regression_module.rv_utils.load_category_total_cases = original_category
+        with mock.patch.object(regression_module.rv_utils, "load_category_total_cases") as load_category:
+            try:
+                config = RegressionConfig(options, _Log())
+            finally:
+                regression_module.rv_utils.calc_simresults_location = original_calc
 
+        load_category.assert_not_called()
+        self.assertEqual({}, config.category_total_cases)
         self.assertEqual([], config.deferred_messages)
         self.assertEqual(0, config.current_time)
 

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -90,6 +90,11 @@ class VcsRuntimeContractTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             parse_args(["--jobs", "0"])
 
+    def test_category_config_is_explicitly_enabled(self):
+        self.assertIsNone(parse_args([]).category_cfg)
+        self.assertEqual("", parse_args(["--category-cfg"]).category_cfg)
+        self.assertEqual("custom.json", parse_args(["--category-cfg", "custom.json"]).category_cfg)
+
     def test_vcs_simv_runtime_keeps_dash_f_filelist(self):
         options = parse_args(["-t", "unit:test", "--simulator", "VCS"])
         simulator = VcsSimulator(options, DummyRegressionConfig(), None)


### PR DESCRIPTION
## Summary
- keep category statistics disabled and silent unless --category-cfg is present
- make bare --category-cfg load proj_dir/category_config.json
- preserve explicit custom config paths

## Validation
- py -3 -m unittest tests.regression_discovery_test
- bazel test --test_output=errors //:buildifier_test //tests:all //tests/vcs_filelist_validation:all
- PR-diff YAPF check