### PR TITLE
Document repository guidance for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# PROJECT KNOWLEDGE BASE
+
+**Reviewed:** 2026-07-13
+**Baseline:** `main@fd3a6a5`
+
+## OVERVIEW
+
+Bazel 7.7.1 rules and Python 3.12 tooling for Verilog RTL/DV builds, Xcelium/VCS simulation, regression scheduling, coverage, and reports. The repository is WORKSPACE-based; Bzlmod is disabled.
+
+## STRUCTURE
+
+```text
+bin/          # simmer CLI, argument parsing, generated-script/report templates
+lib/          # reusable regression, scheduling, simulator, coverage, report logic
+verilog/      # public rule facade and private RTL/DV Starlark implementations
+simulators/   # repository rules that discover installed simulator DPI headers
+vendors/      # Bazel-substituted Cadence, Synopsys, and Real Intent templates
+tests/        # unittest/Bazel tests plus external-workspace and VCS contract fixtures
+examples/     # minimal APB and DPI consumer graphs
+docs/         # directly maintained API and simulator workflow documentation
+deps/         # pinned public and site-local repository declarations
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Add or change a public Verilog rule | `verilog/defs.bzl`, `verilog/private/` | `defs.bzl` is the supported consumer facade |
+| Trace a regression run | `bin/simmer.py`, `lib/regression.py`, `lib/job_lib.py` | Discovery -> job DAG -> simulator backend |
+| Change CLI flags | `bin/args_parse/` | Common and backend flags are separated |
+| Change backend behavior | `lib/simulators/` | `base.py` defines the seam; VCS/Xcelium implement it |
+| Change generated commands or reports | `bin/templates/` | Jinja templates; context comes from `simmer.py` and backends |
+| Change Bazel rule actions | `verilog/private/{rtl,dv,verilog}.bzl` | Shared providers/path logic belongs in `verilog.bzl`; backend logic belongs in `private/simulators/` |
+| Change installed-tool discovery | `simulators/` | Separate from runtime adapters and DV rule backends |
+| Validate generated VCS/XRUN contracts | `tests/vcs_filelist_validation/` | Tool stubs inspect scripts, filelists, and runtime behavior |
+| Change public docs | `README.md`, `docs/defs.md`, `tests/docs_test.py` | Docs are maintained directly and link/anchor tested |
+
+## CODE MAP
+
+| Symbol | Type | Location | Role |
+|--------|------|----------|------|
+| `main` | function | `bin/simmer.py` | Builds and runs the regression job graph |
+| `RegressionConfig` | class | `lib/regression.py` | Bazel discovery, filtering, and cached configuration |
+| `JobManager` | class | `lib/job_lib.py` | Dependency-aware threaded scheduler |
+| `SimulatorInterface` | class | `lib/simulators/base.py` | Runtime backend contract |
+| `VcsSimulator` / `XceliumSimulator` | classes | `lib/simulators/` | Compile, run, waves, coverage, artifact behavior |
+| `verilog_*` exports | rules/macros | `verilog/defs.bzl` | Public Starlark API |
+
+## CONVENTIONS
+
+- Python uses YAPF 0.43.0 with `.style.yapf`; tests use stdlib `unittest` and explicit Bazel `py_test` dependencies.
+- Starlark formatting and linting run through root Buildifier targets. Keep BUILD data/deps synchronized with Python modules and templates.
+- Simulator names are uppercase `XRUN` or `VCS`; `SIM_PLATFORM` selects the CLI default and falls back to XRUN. Each DV target still records its simulator.
+- `simmer` accepts one simulator per invocation. Quote selectors containing `*`.
+- VCS simulation uses `verilog_dv_tb` plus `simmer`. The one-step RTL/DV unit-test rules are XRUN-only; RTL lint supports both backends.
+- Public rule/API changes require direct updates to `docs/defs.md`; docs checks verify anchors and links, not full signature equality.
+- Licensed simulator behavior is validated on Red Hat with Python 3.12. macOS and license-free CI validate generation only.
+
+## PROJECT-SPECIFIC DON'TS
+
+- Do not mix XRUN/VCS flags, templates, wave formats, or tests in one run.
+- Do not hand-maintain MSIE primary/incremental filelists; Bazel and `simmer` generate them.
+- Do not use `../` traversal or environment variables for Bazel-owned filelist paths; retain runfiles-relative paths.
+- Do not load `verilog/private` from new consumer BUILD files. Existing internal use is compatibility-sensitive.
+- Do not assume `//docs:defs_docs` exists: the migration checklist is stale; maintain docs directly.
+- Do not treat `env.sh` or `.bazelrc` site wrappers as portable defaults; `runmod` and licensed tools are external.
+- Do not treat PLDM as a third simulator backend. Its independent Starlark module emits compatibility inputs for Xcelium emulation.
+
+## COMMANDS
+
+```bash
+bazel test --test_output=errors //:buildifier_diff //tests/... //examples/dpi:dpi_c_test
+./tests/doc_test.sh
+bazel run //bin:simmer -- --help
+bazel run //:buildifier_lint
+./tests/redhat_smoke.sh  # Red Hat-compatible host only
+```
+
+Licensed XRUN/VCS tests run separately on a configured Red Hat EDA host. CI does not run them.

--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -1,0 +1,42 @@
+# BIN KNOWLEDGE
+
+## OVERVIEW
+
+Executable/composition layer for `simmer`, parser utilities, generated run scripts, wave commands, and HTML reports.
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Regression orchestration | `simmer.py` | Defines compile/test jobs and assembles the DAG |
+| Common CLI flags | `args_parse/common.py` | Shared XRUN/VCS options |
+| Backend CLI flags | `args_parse/{vcs,xcelium}.py` | Keep backend switches isolated |
+| Parse CLI | `args_parse/parser.py` | Composes common and backend parsers and tracks explicitly supplied switches |
+| Validate backend options | `../lib/simulators/{vcs,xcelium}_options.py` | Validation runs after the selected simulator is resolved |
+| Generated compile/run scripts | `templates/*.j2` | Jinja context comes from `simmer.py` and simulator adapters |
+| Static report pages | `templates/regression_report_templates/` | Rendered by `lib/regression_report.py` |
+| Log checking | `check_test.py` | Importable library target plus executable |
+
+## CONVENTIONS
+
+- Keep `bin/` as orchestration: reusable discovery, scheduling, persistence, and backend mechanics belong in `lib/`.
+- Add CLI options to the matching common/backend parser, then validate them in the selected backend.
+- Templates are Bazel runtime data. Update `bin/BUILD` whenever a module or template dependency changes.
+- Preserve shell quoting and exit-code precedence in generated scripts; simulator failure outranks log-parser failure.
+- Report templates use an autoescaped Jinja environment and depth-sensitive relative links.
+
+## ANTI-PATTERNS
+
+- Do not put VCS switches in Xcelium parsing/templates or XRUN switches in VCS paths.
+- Do not move discovery, scheduling, cache, result-history, or backend job mechanics into `simmer.py`.
+- Do not mechanically rewrite braces: `bin/templates` is Jinja, while `vendors/` uses Bazel string substitution.
+- Do not replace `|shell_quote` or generated command assembly with `eval`.
+- Do not change a template variable without updating every render context and its runtime-contract test.
+
+## CHECKS
+
+```bash
+bazel run //bin:simmer -- --help
+bazel test //tests:check_test_test //tests:normalize_runfiles_flist_test
+bazel test //tests/vcs_filelist_validation:vcs_runtime_contract_test
+```

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -1,0 +1,44 @@
+# LIB KNOWLEDGE
+
+## OVERVIEW
+
+Reusable Python core for discovery, job scheduling, simulator backends, compile caching, results, coverage, and reports.
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Bazel test discovery/config | `regression.py` | Owns discovery cache and test selection |
+| Scheduler and job states | `job_lib.py` | `todo -> ready -> active -> done/skipped` |
+| Simulator contract | `simulators/base.py` | Concrete backends must conform |
+| VCS/Xcelium mechanics | `simulators/{vcs,xcelium}.py` | Commands, waves, coverage, artifact validation |
+| Backend option validation | `simulators/{vcs,xcelium}_options.py` | Reject mixed or unsupported switches |
+| VCS scheduler extensions | `simulators/{vcs_jobs,vso}.py` | VSO/ICO and partition-specific planning |
+| Runtime options | `runtime_options.py` | Normalize, merge, quote, and resolve timeouts |
+| Persistent run history | `simmer_results.py` | Atomic/locked result-store updates |
+| Dashboard rendering | `regression_report.py` | Autoescaped Jinja plus atomic writes |
+
+## CONVENTIONS
+
+- `lib/` must not import `bin/`; `bin/simmer.py` composes these services.
+- Keep simulator branching behind `SimulatorInterface`, not in generic discovery or scheduler code.
+- Keep VCS `-cm`, VSO/ICO, FSDB, and Verdi behavior out of Xcelium; keep MSIE, PLDM/emulation, and Xcelium coverage out of VCS.
+- Preserve scheduler queue ownership, dependency-failure propagation, timeout escalation, and thread-cost accounting.
+- Keep persisted schemas versioned and writes atomic; corruption and concurrent writers have focused tests.
+- Each module has an explicit `py_library` in `lib/BUILD`; update deps instead of relying on ambient imports.
+- Use stdlib `unittest`, `tempfile`, `SimpleNamespace`, and `unittest.mock` in focused module tests.
+
+## ANTI-PATTERNS
+
+- Do not bypass backend option validation or silently accept mixed simulator controls.
+- Do not mutate job status outside the scheduler transition path.
+- Do not make simulator adapters depend on site-specific launcher availability during unit tests.
+- Do not weaken explicit cache fingerprints or artifact validation to make reuse succeed; unrelated untracked files are not cache inputs.
+
+## CHECKS
+
+```bash
+bazel test //tests:job_manager_launch_test //tests:regression_discovery_test
+bazel test //tests:runtime_options_test //tests:compile_cache_test
+bazel test //tests:simmer_results_test //tests:regression_report_test
+```

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,51 @@
+# TEST KNOWLEDGE
+
+## OVERVIEW
+
+Bazel-driven stdlib `unittest` coverage plus nested workspace fixtures and license-free validation of generated simulator contracts.
+
+## STRUCTURE
+
+```text
+*_test.py                 # focused Python unit/behavior tests
+external_fixture/         # standalone WORKSPACE consumed as external IP
+vcs_filelist_validation/  # VCS two-step and XRUN one-step generated contracts
+redhat_smoke.sh           # Red Hat/Python/Bazel portability gate
+doc_test.sh               # direct documentation consistency checks
+```
+
+## CONVENTIONS
+
+- Name files `<module>_test.py`, classes `<Subject>Test`, and methods `test_<behavior>`.
+- Use stdlib `unittest`, `tempfile`, pathlib, `SimpleNamespace`, `unittest.mock`, and small local fakes.
+- Declare one explicit Bazel `py_test` per module with exact library/data dependencies.
+- Prefer tool stubs and generated-artifact inspection for license-free simulator contracts.
+- Keep license-requiring BUILD targets tagged and manual; CI cannot validate real VCS/Xcelium execution.
+- Update `tests/BUILD` when adding tests or fixture data.
+
+## WHERE TO TEST
+
+| Change | Test location |
+|--------|---------------|
+| Core `lib/<module>.py` behavior | matching top-level `<module>_test.py` |
+| Scheduler/process launch | `job_manager_launch_test.py` |
+| Discovery/cache behavior | `regression_discovery_test.py` |
+| Public docs/exports | `docs_test.py`, `doc_test.sh` |
+| VCS two-step and XRUN one-step scripts/filelists | `vcs_filelist_validation/` |
+| External repository paths | `external_fixture/` plus VCS validation tests |
+
+## ANTI-PATTERNS
+
+- Do not make no-license CI invoke real EDA binaries; keep real simulator validation separate on Red Hat.
+- Do not replace precise fixtures with broad mocks that skip rendered commands, quoting, paths, or exit codes.
+- Do not assume all `examples/...` targets are CI-safe; only the native DPI C test is license-free.
+
+## CHECKS
+
+```bash
+bazel test --test_output=errors //:buildifier_diff //tests/... //examples/dpi:dpi_c_test
+bazel test //tests/vcs_filelist_validation:vcs_filelist_validation_test
+bazel test //tests/vcs_filelist_validation:vcs_runtime_contract_test
+./tests/doc_test.sh
+./tests/redhat_smoke.sh  # Red Hat-compatible host only
+```

--- a/vendors/AGENTS.md
+++ b/vendors/AGENTS.md
@@ -1,0 +1,38 @@
+# VENDOR TEMPLATE KNOWLEDGE
+
+## OVERVIEW
+
+Public, overrideable Bazel templates for Cadence Xcelium/HAL/Jasper, Synopsys VCS/Verdi, and Real Intent Ascent lint flows.
+
+## SIMULATOR MATRIX
+
+| Directory | Contract |
+|-----------|----------|
+| `cadence/` | `-define`, `-f`, integrated xrun; HAL lint and Jasper CDC |
+| `synopsys/` | `+define+`, `-file`, compile to `simv`, UCLI/FSDB/Verdi |
+| `real_intent/` | Ascent lint shell/Tcl pair; template label identity affects rule behavior |
+
+## CONVENTIONS
+
+- These files use literal placeholders such as `{FLISTS}` and `{PRE_FLIST_ARGS}` expanded by Starlark actions, not Jinja.
+- Keep each rule's run template, command template, lint parser, rule file, and wrapper command as a coherent vendor bundle.
+- Preserve shell strict mode, quoting, arrays, line continuations, cleanup, and original simulator exit status.
+- Preserve vendor-specific timebases: Cadence DV uses 1ps/1ps, Synopsys DV uses 1ns/1ps, and RTL unit tests use 100fs/100fs.
+- Keep VCS compile/run separation and Xcelium integrated execution distinct.
+- Update the owning `BUILD` exports and generated-contract tests with template changes.
+
+## ANTI-PATTERNS
+
+- Do not normalize Cadence and Synopsys flag syntax or wave formats.
+- Do not execute `cadence/verilog_rtl_lint_cmds.tcl.template`; HAL deliberately has no command script.
+- Do not convert the Synopsys lint `.tcl` file to Tcl; it is intentionally a VCS argument file.
+- Do not rename the Real Intent run-template label without tracing the special-case behavior in `verilog/private/rtl.bzl`.
+- Do not add `-partcomp` to the Synopsys DV compile template; partition compile is managed elsewhere.
+- Do not reflow `{PRE_FLIST_ARGS}` placeholder lines; embedded continuations are part of the generated shell contract.
+
+## CHECKS
+
+```bash
+bazel test //tests/vcs_filelist_validation:vcs_runtime_contract_test
+bazel test //:buildifier_diff
+```

--- a/verilog/AGENTS.md
+++ b/verilog/AGENTS.md
@@ -1,0 +1,52 @@
+# VERILOG RULE KNOWLEDGE
+
+## OVERVIEW
+
+Public Starlark facade plus RTL/DV rule implementations, providers, normalized filelists, and simulator-specific action metadata.
+
+## STRUCTURE
+
+```text
+defs.bzl                  # supported consumer-facing exports
+private/verilog.bzl       # shared providers, paths, inventories, tool settings
+private/rtl.bzl           # RTL libraries, packages, shells, unit/lint/CDC rules
+private/dv.bzl            # DV libraries, testbenches, test configs, unit tests
+private/simulators/       # action metadata for VCS, Xcelium, and PLDM
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Add/change public rule | `defs.bzl` | Alias implementation; update docs directly |
+| Shared source/runfiles model | `private/verilog.bzl` | `VerilogInfo`, depsets, normalized short paths |
+| RTL action behavior | `private/rtl.bzl` | Vendor template bundles must stay coherent |
+| DV simulator dispatch | `private/dv.bzl` | Uppercase XRUN/VCS, TB/test-cfg consistency |
+| Backend-generated metadata | `private/simulators/` | Used during Bazel analysis/action generation; `simmer` consumes the outputs |
+
+## CONVENTIONS
+
+- Consumers load only `//verilog:defs.bzl`; keep public names there and implementation helpers private by convention.
+- Preserve stable, sorted file inventories and normalized `external/...` short paths; avoid `../` traversal.
+- Expand `$location` arguments with matching `extra_runfiles` and `ctx.expand_location`.
+- Simulator-specific defaults and validation belong in the matching backend path.
+- VCS simulation is the two-step `verilog_dv_tb` plus `simmer` flow. One-step RTL/DV unit-test rules are XRUN-only; lint supports XRUN and VCS.
+- Keep PLDM in its independent module, but treat its outputs as Xcelium emulation compatibility data rather than a third runtime backend.
+- Update `docs/defs.md` and docs tests for public exports, attributes, defaults, or descriptions.
+- Keep dependency declarations as providers/depsets and return complete `DefaultInfo` runfiles.
+
+## ANTI-PATTERNS
+
+- Do not tighten `verilog/private` visibility casually; existing Python discovery and tests consume private aspects/files.
+- Do not put packages or shells in `verilog_rtl_library`; use `verilog_rtl_pkg` and `verilog_rtl_shell`.
+- Do not set internal `is_pkg`/`is_shell_of`, use deprecated `sim_args`, or combine legacy `ccf` with `xcelium_covfile`.
+- Do not glob DPI shared libraries into `srcs`; use the `dpi` attribute.
+- Do not remove compatibility outputs or dormant checks without updating contract tests and consumers.
+
+## CHECKS
+
+```bash
+bazel test //:buildifier_diff
+bazel query //verilog/private:all
+./tests/doc_test.sh
+```


### PR DESCRIPTION
## Summary

- add repository-wide guidance for Bazel, Python, simulator, vendor, and test changes
- add scoped guidance under `bin`, `lib`, `tests`, `vendors`, and `verilog`
- document the current VCS/XRUN separation, PLDM boundary, supported workflows, and validation commands

## Why

The guidance was generated against an older feature branch and was not tracked. This refresh aligns it with `main@fd3a6a5` so coding agents use the current repository structure and simulator contracts.

## Validation

- `bazel test --test_output=errors //:buildifier_diff //tests/... //examples/dpi:dpi_c_test`
- `./tests/doc_test.sh`
- `bazel run //bin:simmer -- --help`
- `git diff --staged --check`