### PR TITLE
Fix external simulator integration

### DIFF
--- a/.github/workflows/bazel_tests.yml
+++ b/.github/workflows/bazel_tests.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: install-python-dependencies
+        run: python -m pip install -r requirements.txt
+
       - name: install-bazelisk
         uses: vsco/bazelisk-action@170327f90b7b6c4364a97741d6e64f888d76bcb5
         with:
@@ -59,10 +62,13 @@ jobs:
       USE_BAZEL_VERSION: "7.7.1"
     steps:
       - name: install-system-dependencies
-        run: dnf install -y gcc gcc-c++ git gzip python3.12 tar unzip which zip
+        run: dnf install -y gcc gcc-c++ git gzip python3.12 python3.12-pip tar unzip which zip
 
       - name: checkout
         uses: actions/checkout@v4
+
+      - name: install-python-dependencies
+        run: python3.12 -m pip install -r requirements.txt
 
       - name: install-bazelisk
         uses: vsco/bazelisk-action@170327f90b7b6c4364a97741d6e64f888d76bcb5

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ to be available on `PATH`.
 ### VCS Partition Compile
 
 VCS regressions use Partition Compile by default. The writable partition
-database is `<tb>__VCS_VCOMP/partitionlib`, so stable third-party IP/VIP
+database is `<tb>__VCS_VCOMP/partitionlib`; `--waves` and `--gui` use sibling
+`partitionlib_waves` and `partitionlib_gui` databases so incompatible KDB
+options do not invalidate each other. Stable third-party IP/VIP
 partitions are reused while changed project RTL and testbench partitions are
 rebuilt. Tune parallel compilation after measuring the workstation:
 
@@ -253,19 +255,19 @@ compile configuration, or the selected simulator tool environment changes.
 Recent normal-run compile/start failures remain visible through `simmer --history`.
 
 ### Python Dependencies
-rules_verilog is also dependent on several python libraries. These are defined in requirements.txt and may be installed in the package manager of your choice. The recommended flow is to install them via the `pip_parse` rule in your `WORKSPACE` file:
+rules_verilog uses the Python libraries listed in `requirements.txt`, but it
+does not create a pip repository or install them. The top-level project owns
+Python dependency installation so that every external rules repository shares
+the same environment. Install the requirements into the Python 3.12 environment
+used by Bazel before running `simmer`:
 
-```skylark
-load("@rules_python//python:pip.bzl", "pip_parse")
-
-pip_parse(
-    name = "pip_deps",
-    requirements_lock = "@rules_verilog//:requirements.txt",
-)
-
-load("@pip_deps//:requirements.bzl", "install_deps")
-install_deps()
+```bash
+python3.12 -m pip install -r path/to/rules_verilog/requirements.txt
 ```
+
+rules_verilog BUILD packages intentionally avoid workspace-owned Python
+requirement labels so `@rules_verilog//bin:simmer` can be loaded from an
+external repository.
 
 ### Red Hat validation
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,18 +13,6 @@ load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-load("@rules_python//python:pip.bzl", "pip_parse")
-
-pip_parse(
-    name = "pip_deps",
-    python_interpreter = "python3.12",
-    requirements_lock = "//:requirements.txt",
-)
-
-load("@pip_deps//:requirements.bzl", "install_deps")
-
-install_deps()
-
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()

--- a/bin/BUILD
+++ b/bin/BUILD
@@ -1,5 +1,3 @@
-load("@pip_deps//:requirements.bzl", "requirement")
-
 # vim: set ft=bzl :
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
@@ -21,7 +19,6 @@ py_binary(
     srcs = ["lint_parser_hal.py"],
     deps = [
         "//lib:cmn_logging",
-        requirement("beautifulsoup4"),
     ],
 )
 
@@ -41,9 +38,10 @@ py_binary(
     name = "simmer",
     srcs = ["simmer.py"],
     data = glob(["templates/**"]),
+    imports = ["."],
     deps = [
-        "//bin:args_parser",
-        "//bin:check_test",
+        "//bin:args_parser_lib",
+        "//bin:check_test_lib",
         "//lib:cmn_logging",
         "//lib:compile_cache",
         "//lib:job_lib",
@@ -56,7 +54,6 @@ py_binary(
         "//lib:sim_artifacts",
         "//lib:simmer_results",
         "//lib/simulators",
-        requirement("jinja2"),
     ],
 )
 

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -239,11 +239,6 @@ class VCompJob(Job):
             "dut_instance": "hdl_top.dut",
             "dut_top": "dut",
             "compile_inputs": "",
-            "vcs_cm_hier": "",
-            "xcelium_covfile": "",
-            "msie_primary_compile_args": "",
-            "msie_incremental_compile_args": "",
-            "msie_primary_inputs": "",
         }
         if os.path.isfile(tb_options_path):
             with open(tb_options_path, "r", encoding="utf-8") as filep:

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -7,7 +7,7 @@ Public entry point to all supported Verilog rules and APIs
 ## verilog_dv_library
 
 <pre>
-verilog_dv_library(<a href="#verilog_dv_library-name">name</a>, <a href="#verilog_dv_library-deps">deps</a>, <a href="#verilog_dv_library-dpi">dpi</a>, <a href="#verilog_dv_library-in_flist">in_flist</a>, <a href="#verilog_dv_library-incdir">incdir</a>, <a href="#verilog_dv_library-srcs">srcs</a>)
+verilog_dv_library(<a href="#verilog_dv_library-name">name</a>, <a href="#verilog_dv_library-deps">deps</a>, <a href="#verilog_dv_library-dpi">dpi</a>, <a href="#verilog_dv_library-in_flist">in_flist</a>, <a href="#verilog_dv_library-incdir">incdir</a>, <a href="#verilog_dv_library-makelib">makelib</a>, <a href="#verilog_dv_library-srcs">srcs</a>)
 </pre>
 
 A DV Library.
@@ -45,6 +45,7 @@ verilog_dv_library(
 | <a id="verilog_dv_library-dpi"></a>dpi |  cc_libraries to link in through the DPI. Currently, cc_import is not supported for precompiled shared libraries. Prefer placing shared libraries here rather than globbing `.so` files into `srcs`. Example: `cc_library(name = "dpi", srcs = glob(["*.c"]))` then `verilog_dv_library(name = "pkg", srcs = glob(["*.sv"]), dpi = [":dpi"])`.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="verilog_dv_library-in_flist"></a>in_flist |  Files to be placed directly in the generated flist. Best practice recommends 'pkg' and 'interface' files be declared here. If this attribute is empty (default), all srcs will put into the flist instead.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="verilog_dv_library-incdir"></a>incdir |  Generate a +incdir in generated flist for every file's directory declared in 'srcs' attribute.   | Boolean | optional | True |
+| <a id="verilog_dv_library-makelib"></a>makelib |  Compile this target into the named Xcelium library through `-makelib`/`-endlib`. VCS receives the same ordered sources through a separate `-file` boundary; VCS recompilation isolation is provided by `-Mupdate` and Partition Compile rather than Xcelium library syntax.   | String | optional | `""` |
 | <a id="verilog_dv_library-srcs"></a>srcs |  Systemverilog source files. Files are assumed to be \<code>included inside another file (e.g. the package file) and will not be placed on directly in the flist unless declared in the 'in_flist' attribute.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 
@@ -202,7 +203,7 @@ Run Jaspergold CDC on a verilog_rtl_library.
 
 <pre>
 verilog_rtl_library(<a href="#verilog_rtl_library-name">name</a>, <a href="#verilog_rtl_library-deps">deps</a>, <a href="#verilog_rtl_library-direct">direct</a>, <a href="#verilog_rtl_library-enable_gumi">enable_gumi</a>, <a href="#verilog_rtl_library-gumi_file_override">gumi_file_override</a>, <a href="#verilog_rtl_library-gumi_override">gumi_override</a>, <a href="#verilog_rtl_library-headers">headers</a>,
-                    <a href="#verilog_rtl_library-is_pkg">is_pkg</a>, <a href="#verilog_rtl_library-is_shell_of">is_shell_of</a>, <a href="#verilog_rtl_library-lib_files">lib_files</a>, <a href="#verilog_rtl_library-modules">modules</a>, <a href="#verilog_rtl_library-no_synth">no_synth</a>)
+                    <a href="#verilog_rtl_library-is_pkg">is_pkg</a>, <a href="#verilog_rtl_library-is_shell_of">is_shell_of</a>, <a href="#verilog_rtl_library-lib_files">lib_files</a>, <a href="#verilog_rtl_library-makelib">makelib</a>, <a href="#verilog_rtl_library-modules">modules</a>, <a href="#verilog_rtl_library-no_synth">no_synth</a>)
 </pre>
 
 A collection of RTL design files. Creates a generated flist file to be included later in a compile.
@@ -222,8 +223,9 @@ A collection of RTL design files. Creates a generated flist file to be included 
 | <a id="verilog_rtl_library-is_pkg"></a>is_pkg |  INTERNAL: Do not set in verilog_rtl_library instances. Used for internal bookkeeping for macros derived from verilog_rtl_library. Used to enforce naming conventions related to packages to encourage simple dependency graphs   | Boolean | optional | False |
 | <a id="verilog_rtl_library-is_shell_of"></a>is_shell_of |  INTERNAL: Do not set in verilog_rtl_library instances. Used for internal bookkeeping for macros derived from verilog_rtl_library. If set, this library is represents a 'shell' of another module. Allows downstream test rules to specify this Label as a 'shell' to override another instance via the gumi system.   | String | optional | "" |
 | <a id="verilog_rtl_library-lib_files"></a>lib_files |  Verilog library files containing multiple modules. A '-v' flag will be added for each file in this attribute. It is preferable to used the 'modules' attribute when possible because library files require parsing entire files to discover all modules.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="verilog_rtl_library-makelib"></a>makelib |  Compile this target into the named Xcelium library through `-makelib`/`-endlib`. VCS receives the same ordered sources through a separate `-file` boundary; VCS recompilation isolation is provided by `-Mupdate` and Partition Compile rather than Xcelium library syntax.   | String | optional | `""` |
 | <a id="verilog_rtl_library-modules"></a>modules |  Verilog files containing a single module where the module name matches the file name. A '-y' flag will be added for each source file's directory. This is the preferred mechanism for specifying RTL modules.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="verilog_rtl_library-no_synth"></a>no_synth |  Reserved compatibility attribute. Setting it to True fails analysis because this repository has no synthesis consumer that can enforce filtering. Filter simulation-only targets in the synthesis rule instead.   | Boolean | optional | False |
+| <a id="verilog_rtl_library-no_synth"></a>no_synth |  Compatibility marker for downstream synthesis aspects or consumers. Simulation targets continue to include this library.   | Boolean | optional | False |
 
 
 <a id="verilog_rtl_lint_test"></a>
@@ -362,7 +364,7 @@ should not need to depend on all the modules in the block.
 | :------------- | :------------- | :------------- |
 | <a id="verilog_rtl_pkg-name"></a>name |  A unique name for this target.   |  none |
 | <a id="verilog_rtl_pkg-direct"></a>direct |  The Systemverilog file containing the package.<br><br>See verilog_rtl_library::direct.   |  none |
-| <a id="verilog_rtl_pkg-no_synth"></a>no_synth |  Reserved for compatibility. True is rejected because this repository cannot enforce synthesis filtering.   |  <code>False</code> |
+| <a id="verilog_rtl_pkg-no_synth"></a>no_synth |  Compatibility marker for downstream synthesis aspects or consumers. Simulation targets continue to include this package.   |  <code>False</code> |
 | <a id="verilog_rtl_pkg-deps"></a>deps |  Other packages this target is dependent on.<br><br>See verilog_rtl_library::deps.   |  <code>[]</code> |
 | <a id="verilog_rtl_pkg-visibility"></a>visibility |  Bazel target visibility.   |  <code>None</code> |
 

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -155,6 +155,22 @@ simulation when the existing compile output does not match the current inputs.
 
 Use `--recompile` to force a clean VCS compile.
 
+### `makelib` and VCS reuse
+
+`verilog_rtl_library.makelib` and `verilog_dv_library.makelib` create a named
+Xcelium library with `-makelib`/`-endlib`. VCS must not receive those Xcelium
+tokens. It receives a companion filelist with the same ordered sources, and
+each Bazel library remains a separate `-file` input rather than being flattened
+into the testbench filelist.
+
+VCS recompilation isolation comes from `-Mupdate` and Partition Compile, not
+from the Xcelium library name. Keep stable RTL/IP in separate Bazel libraries
+so their filelist boundaries remain visible to the VCS compile. When automatic
+partitioning does not isolate a component well enough, declare its actual cells
+or packages in a VCS optconfig file as described below. A `makelib` string is
+not sufficient to generate that config because one library may contain several
+cells and packages.
+
 ### VCS Partition Compile
 
 VCS Y-2026.03 Partition Compile is enabled by default with adaptive scheduling,
@@ -171,6 +187,13 @@ The partition database belongs to one VCOMP directory rather than the shared
 Bazel runfiles tree. A normal internal RTL or testbench edit therefore rebuilds
 only affected partitions while unchanged third-party PCIe, UCIe, Ethernet,
 RISC-V and NoC IP/VIP partitions remain reusable.
+
+The default non-debug database remains `partitionlib`. `--waves` and `--gui`
+use sibling `partitionlib_waves` and `partitionlib_gui` databases because their
+KDB/debug-access options are not compatible with a non-debug partition build.
+Explicit `--vcs-partcomp-dir` and `--vcs-partcomp-sharedlib` paths are used
+exactly as supplied, so custom databases must be versioned separately for each
+debug, coverage, define and compile-argument configuration.
 
 Use the default local database for one workspace. Profile and tune parallelism
 with:

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,5 +1,3 @@
-load("@pip_deps//:requirements.bzl", "requirement")
-
 # vim: set ft=bzl :
 load("@rules_python//python:defs.bzl", "py_library")
 
@@ -53,7 +51,6 @@ py_library(
 py_library(
     name = "regression_report",
     srcs = ["regression_report.py"],
-    deps = [requirement("jinja2")],
 )
 
 py_library(

--- a/lib/simulators/BUILD
+++ b/lib/simulators/BUILD
@@ -1,7 +1,5 @@
 # vim: set ft=bzl :
 # lib/simulators/BUILD
-load("@pip_deps//:requirements.bzl", "requirement")
-
 package(default_visibility = ["//visibility:public"])
 
 py_library(
@@ -18,7 +16,6 @@ py_library(
         ":options",
         ":xcelium_options",
         "//lib:coverage_data",
-        requirement("jinja2"),
     ],
 )
 

--- a/lib/simulators/vcs.py
+++ b/lib/simulators/vcs.py
@@ -260,9 +260,10 @@ class VcsSimulator(SimulatorInterface):
     def get_partition_compile_options(self, vcomp_job):
         jobs = '-fastpartcomp=j{}'.format(self.options.vcs_partcomp_jobs)
         if self.options.dtl:
+            dtl_dir = os.path.join(vcomp_job.job_dir, self._debug_partition_dirname('dtl_static'))
             return shlex.join([
                 '-partcomp',
-                '-dir={}'.format(os.path.join(vcomp_job.job_dir, 'dtl_static')),
+                '-dir={}'.format(dtl_dir),
                 jobs,
             ])
 
@@ -270,7 +271,10 @@ class VcsSimulator(SimulatorInterface):
         if mode_option is None:
             return ''
 
-        partition_dir = self.options.vcs_partcomp_dir or os.path.join(vcomp_job.job_dir, 'partitionlib')
+        partition_dir = self.options.vcs_partcomp_dir or os.path.join(
+            vcomp_job.job_dir,
+            self._debug_partition_dirname('partitionlib'),
+        )
         if not os.path.isabs(partition_dir):
             partition_dir = os.path.join(self.rcfg.proj_dir, partition_dir)
         args = [
@@ -282,6 +286,13 @@ class VcsSimulator(SimulatorInterface):
         if self.options.vcs_partcomp_sharedlib is not None:
             args.append('-partcomp_sharedlib={}'.format(os.path.abspath(self.options.vcs_partcomp_sharedlib)))
         return shlex.join(args)
+
+    def _debug_partition_dirname(self, base_name):
+        if self.options.gui:
+            return base_name + '_gui'
+        if self.options.waves is not None:
+            return base_name + '_waves'
+        return base_name
 
     def _find_vcs_xprop_config(self, bench_dir, xprop_mode):
         for cfg_name in self.VCS_XPROP_CONFIG_BY_MODE.get(xprop_mode, []):

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -62,6 +62,17 @@ py_test(
 )
 
 py_test(
+    name = "external_python_deps_test",
+    srcs = ["external_python_deps_test.py"],
+    data = [
+        "//:WORKSPACE",
+        "//bin:BUILD",
+        "//lib:BUILD",
+        "//lib/simulators:BUILD",
+    ],
+)
+
+py_test(
     name = "job_manager_launch_test",
     srcs = ["job_manager_launch_test.py"],
     deps = [
@@ -111,6 +122,13 @@ py_test(
     name = "simmer_results_test",
     srcs = ["simmer_results_test.py"],
     deps = ["//lib:simmer_results"],
+)
+
+py_test(
+    name = "simmer_entrypoint_test",
+    srcs = ["simmer_entrypoint_test.py"],
+    args = ["$(location //bin:simmer)"],
+    data = ["//bin:simmer"],
 )
 
 buildifier(

--- a/tests/external_python_deps_test.py
+++ b/tests/external_python_deps_test.py
@@ -1,0 +1,24 @@
+import unittest
+from pathlib import Path
+
+
+class ExternalPythonDepsTest(unittest.TestCase):
+
+    def test_bazel_packages_do_not_require_workspace_owned_pip_repo(self):
+        workspace = Path(__file__).resolve().parents[1]
+        paths = [
+            workspace / "WORKSPACE",
+            workspace / "bin" / "BUILD",
+            workspace / "lib" / "BUILD",
+            workspace / "lib" / "simulators" / "BUILD",
+        ]
+
+        for path in paths:
+            contents = path.read_text(encoding="utf-8")
+            with self.subTest(path=path):
+                self.assertNotIn("@pip_deps", contents)
+                self.assertNotIn("pip_parse(", contents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/redhat_smoke.sh
+++ b/tests/redhat_smoke.sh
@@ -15,6 +15,10 @@ if [[ "$(bazel --version)" != "bazel 7.7.1" ]]; then
   exit 1
 fi
 
-bazel test --test_output=errors //:buildifier_diff //tests/... //examples/dpi:dpi_c_test
+bazel test \
+  --incompatible_use_python_toolchains=false \
+  --python_path=/usr/bin/python3.12 \
+  --test_output=errors \
+  //:buildifier_diff //tests/... //examples/dpi:dpi_c_test
 bazel run //:buildifier_lint
 ./tests/doc_test.sh

--- a/tests/simmer_entrypoint_test.py
+++ b/tests/simmer_entrypoint_test.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+import unittest
+
+SIMMER = sys.argv.pop(1)
+
+
+class SimmerEntrypointTest(unittest.TestCase):
+
+    def test_help_runs_from_bazel_launcher(self):
+        result = subprocess.run(
+            [SIMMER, "--help"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("usage: simmer", result.stdout)
+        self.assertIn("--simulator {VCS,XRUN}", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vcs_filelist_validation/BUILD
+++ b/tests/vcs_filelist_validation/BUILD
@@ -39,8 +39,8 @@ verilog_rtl_library(
 
 verilog_dv_library(
     name = "dv_makelib",
-    makelib = "dv_unit_test_lib",
     srcs = ["unit_test_top.sv"],
+    makelib = "dv_unit_test_lib",
 )
 
 verilog_rtl_lint_test(

--- a/tests/vcs_filelist_validation/BUILD
+++ b/tests/vcs_filelist_validation/BUILD
@@ -2,6 +2,7 @@
 load("@rules_python//python:defs.bzl", "py_test")
 load(
     "@rules_verilog//verilog:defs.bzl",
+    "verilog_dv_library",
     "verilog_dv_tb",
     "verilog_dv_test_cfg",
     "verilog_dv_unit_test",
@@ -25,8 +26,21 @@ sh_binary(
 
 verilog_rtl_library(
     name = "unit_test_top",
+    makelib = "unit_test_lib",
     modules = ["unit_test_top.sv"],
     deps = ["@filelist_external_fixture//:external_rtl"],
+)
+
+verilog_rtl_library(
+    name = "no_synth_compat",
+    modules = ["unit_test_top.sv"],
+    no_synth = True,
+)
+
+verilog_dv_library(
+    name = "dv_makelib",
+    makelib = "dv_unit_test_lib",
+    srcs = ["unit_test_top.sv"],
 )
 
 verilog_rtl_lint_test(
@@ -116,6 +130,7 @@ py_test(
         ":dv_cfg_vcs",
         ":dv_cfg_vcs_inherited",
         ":dv_cfg_vcs_no_timeout",
+        ":dv_makelib",
         ":dv_tb_vcs",
         ":dv_tb_vcs_compile_args.f",
         ":dv_tb_vcs_runtime_args.f",
@@ -124,9 +139,11 @@ py_test(
         ":dv_tb_xrun_ccf_compile_args.f",
         ":dv_tb_xrun_ccf_tb_options.py",
         ":dv_unit_xrun",
+        ":no_synth_compat",
         ":rtl_lint_vcs",
         ":rtl_lint_vcs_cmds.tcl",
         ":rtl_unit_xrun",
+        ":unit_test_top",
         ":vcs_partitions",
         "@filelist_external_fixture//:external_rtl",
     ],

--- a/tests/vcs_filelist_validation/validate_vcs_filelist_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_filelist_test.py
@@ -79,6 +79,31 @@ def assert_lacks_legacy_filelist_flag(contents, relative_path):
 
 class VcsFilelistValidationTest(unittest.TestCase):
 
+    def test_no_synth_remains_compatible_with_simulation_analysis(self):
+        filelist = read_runfile("tests/vcs_filelist_validation/no_synth_compat.f")
+        self.assertIn("tests/vcs_filelist_validation/unit_test_top.sv", filelist)
+
+    def test_makelib_is_xrun_only_and_vcs_keeps_the_source_boundary(self):
+        xrun_filelist = read_runfile("tests/vcs_filelist_validation/unit_test_top.f")
+        vcs_filelist = read_runfile("tests/vcs_filelist_validation/unit_test_top_vcs.f")
+        dv_xrun_filelist = read_runfile("tests/vcs_filelist_validation/dv_makelib.f")
+        dv_vcs_filelist = read_runfile("tests/vcs_filelist_validation/dv_makelib_vcs.f")
+        vcs_compile_args = read_runfile("tests/vcs_filelist_validation/dv_tb_vcs_compile_args.f")
+
+        self.assertIn("-makelib\nunit_test_lib\n", xrun_filelist)
+        self.assertIn("-endlib", xrun_filelist)
+        self.assertNotIn("-makelib", vcs_filelist)
+        self.assertNotIn("-endlib", vcs_filelist)
+        self.assertNotIn("unit_test_lib", vcs_filelist)
+        self.assertIn("tests/vcs_filelist_validation/unit_test_top.sv", vcs_filelist)
+        self.assertIn("-makelib\ndv_unit_test_lib\n", dv_xrun_filelist)
+        self.assertIn("-endlib", dv_xrun_filelist)
+        self.assertNotIn("-makelib", dv_vcs_filelist)
+        self.assertNotIn("-endlib", dv_vcs_filelist)
+        self.assertNotIn("dv_unit_test_lib", dv_vcs_filelist)
+        self.assertIn("tests/vcs_filelist_validation/unit_test_top.sv", dv_vcs_filelist)
+        self.assertIn("-file tests/vcs_filelist_validation/unit_test_top_vcs.f", vcs_compile_args)
+
     def test_dv_test_cfg_keeps_its_public_runtime_contract(self):
         dynamic_args = ast.literal_eval(read_runfile("tests/vcs_filelist_validation/dv_cfg_vcs_dynamic_args.py", ))
 
@@ -106,12 +131,12 @@ class VcsFilelistValidationTest(unittest.TestCase):
             ],
             "tests/vcs_filelist_validation/rtl_lint_vcs_cmds.tcl": [
                 "+define+LINT",
-                "-file tests/vcs_filelist_validation/unit_test_top.f",
+                "-file tests/vcs_filelist_validation/unit_test_top_vcs.f",
                 "-file vendors/synopsys/verilog_rtl_lint_default_opts.f",
             ],
             "tests/vcs_filelist_validation/dv_tb_vcs_compile_args.f": [
                 "-file external/filelist_external_fixture/external_rtl.f",
-                "-file tests/vcs_filelist_validation/unit_test_top.f",
+                "-file tests/vcs_filelist_validation/unit_test_top_vcs.f",
                 "+define+CADENCE_WORKAROUND",
                 "+define+UNIFIED_VCS_COMPILE_ARG",
                 "+define+XRUNNER",
@@ -154,10 +179,16 @@ class VcsFilelistValidationTest(unittest.TestCase):
 
         vcs_options = ast.literal_eval(read_runfile("tests/vcs_filelist_validation/dv_tb_vcs_tb_options.py"))
         self.assertEqual("tests/vcs_filelist_validation/coverage_hier.cfg", vcs_options["vcs_cm_hier"])
+        self.assertNotIn("xcelium_covfile", vcs_options)
+        self.assertNotIn("msie_primary_compile_args", vcs_options)
+        self.assertNotIn("msie_incremental_compile_args", vcs_options)
+        self.assertNotIn("msie_primary_inputs", vcs_options)
 
         compile_inputs = read_runfile(vcs_options["compile_inputs"])
         self.assertIn("source\ttests/vcs_filelist_validation/unit_test_top.sv", compile_inputs)
         self.assertIn("source\texternal/filelist_external_fixture/external_ip.sv", compile_inputs)
+        self.assertIn("filelist\ttests/vcs_filelist_validation/unit_test_top_vcs.f", compile_inputs)
+        self.assertNotIn("filelist\ttests/vcs_filelist_validation/unit_test_top.f\n", compile_inputs)
         self.assertIn("runfile\ttests/vcs_filelist_validation/coverage_hier.cfg", compile_inputs)
 
     def test_xcelium_msie_filelists_are_bazel_generated_and_partitioned(self):
@@ -177,10 +208,12 @@ class VcsFilelistValidationTest(unittest.TestCase):
         self.assertIn("-f external/filelist_external_fixture/external_rtl.f", incremental)
         self.assertIn("source\ttests/vcs_filelist_validation/unit_test_top.sv", inputs)
         self.assertIn("filelist\ttests/vcs_filelist_validation/unit_test_top.f", inputs)
+        self.assertNotIn("filelist\ttests/vcs_filelist_validation/unit_test_top_vcs.f", inputs)
         self.assertIn("runfile\ttests/vcs_filelist_validation/coverage.ccf", inputs)
         self.assertEqual(primary_path, tb_options["msie_primary_compile_args"])
         self.assertEqual(incremental_path, tb_options["msie_incremental_compile_args"])
         self.assertEqual(inputs_path, tb_options["msie_primary_inputs"])
+        self.assertNotIn("vcs_cm_hier", tb_options)
 
     def test_unit_test_scripts_use_xcelium(self):
         scripts = {

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -452,6 +452,39 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertIn("-partcomp=incr_clean", partcomp_args)
         self.assertIn("-fastpartcomp=j8", partcomp_args)
 
+    def test_vcs_partition_compile_separates_kdb_modes(self):
+        vcomp = DummyVcompJob()
+        expected = {
+            "--gui": "partitionlib_gui",
+            "--waves": "partitionlib_waves",
+        }
+
+        for option, dirname in expected.items():
+            with self.subTest(option=option):
+                options = parse_args(["-t", "unit:test", "--simulator", "VCS", option])
+                simulator = VcsSimulator(options, DummyRegressionConfig(), None)
+                partcomp_args = shlex.split(simulator.generate_compile_options(vcomp)["partcomp_opts"])
+
+                self.assertIn("-partcomp_dir={}".format(os.path.join(vcomp.job_dir, dirname)), partcomp_args)
+
+    def test_vcs_custom_partition_directory_is_not_renamed_for_waves(self):
+        custom_dir = os.path.join(tempfile.gettempdir(), "custom_partitionlib")
+        options = parse_args([
+            "-t",
+            "unit:test",
+            "--simulator",
+            "VCS",
+            "--waves",
+            "--vcs-partcomp-dir",
+            custom_dir,
+        ])
+        simulator = VcsSimulator(options, DummyRegressionConfig(), None)
+
+        partcomp_args = shlex.split(simulator.generate_compile_options(DummyVcompJob())["partcomp_opts"])
+
+        self.assertIn("-partcomp_dir={}".format(os.path.abspath(custom_dir)), partcomp_args)
+        self.assertNotIn("-partcomp_dir={}_waves".format(os.path.abspath(custom_dir)), partcomp_args)
+
     def test_vcs_coverage_detail_options_follow_command_reference(self):
         options, simulator = self._validated([
             "--simulator",
@@ -1142,6 +1175,12 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertIn("xcelium_dv_backend", dv_bzl)
         self.assertNotIn('filelist_flag = "-file"', dv_bzl)
         self.assertIn('"\\n-file"', vcs_backend)
+        self.assertIn('"transitive_vcs_flists"', vcs_backend)
+        self.assertIn('fallback_field = "transitive_flists"', vcs_backend)
+        self.assertIn('"vcs_cm_hier"', vcs_backend)
+        self.assertNotIn('"msie_primary_compile_args"', vcs_backend)
+        self.assertIn('"msie_primary_compile_args"', xcelium_backend)
+        self.assertIn("tb_options.update(backend.tb_options", dv_bzl)
         self.assertNotIn("_ut_sim_template_xrun_default", vcs_backend)
         self.assertNotIn("_default_sim_opts_xrun_default", vcs_backend)
         self.assertIn("does not support simulator = 'VCS'", dv_bzl)
@@ -1158,8 +1197,8 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertIn('defines.extend(["+define+{}{}', rtl_bzl)
         self.assertNotIn('defines.extend(["+{}{}', rtl_bzl)
         self.assertIn("[_gatesim_target(inherit, corner) for inherit in inherits]", dv_bzl)
-        self.assertIn("sets no_synth=True, but rules_verilog has no synthesis consumer", rtl_bzl)
-        self.assertNotIn("        no_synth = True,", rtl_bzl)
+        self.assertIn("Compatibility marker for downstream synthesis", rtl_bzl)
+        self.assertNotIn("sets no_synth=True", rtl_bzl)
         self.assertNotIn('"_runtime_args_template"', dv_bzl)
 
 

--- a/verilog/private/dv.bzl
+++ b/verilog/private/dv.bzl
@@ -360,6 +360,17 @@ def verilog_dv_test_cfg(name = None, tags = None, abstract = None, inherits = No
 def _is_dpi_shared_lib(path):
     return path.endswith(".so") or path.endswith(".dll") or path.endswith(".dylib")
 
+def _dv_library_flist_content(directories, in_flist, makelib = ""):
+    content = []
+    if makelib:
+        content.extend(["-makelib", makelib])
+    for directory in directories:
+        content.append("+incdir+{}".format(directory if directory else "."))
+    content.extend([runfiles_relative_short_path(f) for f in in_flist])
+    if makelib:
+        content.append("-endlib")
+    return content
+
 def _verilog_dv_library_impl(ctx):
     if ctx.attr.incdir:
         # Using dirname may result in bazel-out included in path
@@ -375,23 +386,7 @@ def _verilog_dv_library_impl(ctx):
     else:
         in_flist = ctx.files.srcs
 
-    content = []
-
-    # If using makelib, start here
-    if ctx.attr.makelib:
-        content.append("-makelib")
-        content.append(ctx.attr.makelib)
-
-    for d in directories:
-        if d == "":
-            d = "."
-        content.append("+incdir+{}".format(d))
-    for f in in_flist:
-        content.append(runfiles_relative_short_path(f))
-
-    # if using makelib, terminate here
-    if ctx.attr.makelib:
-        content.append("-endlib")
+    content = _dv_library_flist_content(directories, in_flist, ctx.attr.makelib)
 
     all_sos = []
     for dpi in ctx.attr.dpi:
@@ -408,15 +403,35 @@ def _verilog_dv_library_impl(ctx):
         output = out,
         content = "\n".join(content),
     )
+    vcs_out = out
+    if ctx.attr.makelib:
+        vcs_out = ctx.actions.declare_file(ctx.label.name + "_vcs.f")
+        ctx.actions.write(
+            output = vcs_out,
+            content = "\n".join(_dv_library_flist_content(directories, in_flist)),
+        )
 
     trans_srcs = get_transitive_srcs(ctx.files.srcs, ctx.attr.deps + ctx.attr.dpi, VerilogInfo, "transitive_sources", allow_other_outputs = True)
     trans_flists = get_transitive_srcs([out], ctx.attr.deps, VerilogInfo, "transitive_flists", allow_other_outputs = False)
+    trans_vcs_flists = get_transitive_srcs(
+        [vcs_out],
+        ctx.attr.deps,
+        VerilogInfo,
+        "transitive_vcs_flists",
+        allow_other_outputs = False,
+        fallback_attr_name = "transitive_flists",
+    )
     trans_dpi = get_transitive_srcs(all_sos, ctx.attr.deps, VerilogInfo, "transitive_dpi", allow_other_outputs = False)
 
-    all_files = depset(transitive = [trans_srcs, trans_flists])
+    all_files = depset(transitive = [trans_srcs, trans_flists, trans_vcs_flists])
 
     return [
-        VerilogInfo(transitive_sources = trans_srcs, transitive_flists = trans_flists, transitive_dpi = trans_dpi),
+        VerilogInfo(
+            transitive_sources = trans_srcs,
+            transitive_flists = trans_flists,
+            transitive_vcs_flists = trans_vcs_flists,
+            transitive_dpi = trans_dpi,
+        ),
         DefaultInfo(
             files = all_files,
             runfiles = ctx.runfiles(transitive_files = all_files),
@@ -476,8 +491,8 @@ verilog_dv_library = rule(
         ),
         "makelib": attr.string(
             default = "",
-            doc = "Used to specify that this DV lib should be compiled into its own library.\n" +
-                  "String value specified here is used as the name of the compile lib.",
+            doc = ("Compile this target into the named Xcelium library through -makelib/-endlib. " +
+                   "VCS receives the same ordered sources through a separate -file boundary; VCS recompilation isolation is provided by -Mupdate and Partition Compile rather than Xcelium library syntax."),
         ),
     },
     outputs = {"out": "%{name}.f"},
@@ -569,20 +584,22 @@ def _verilog_dv_tb_impl(ctx):
     )
     ctx.actions.write(
         output = ctx.outputs.compile_inputs,
-        content = verilog_input_inventory(all_deps, compile_input_files),
+        content = verilog_input_inventory(
+            all_deps,
+            compile_input_files,
+            flist_field = compile_config.flist_field,
+            fallback_field = compile_config.fallback_flist_field,
+        ),
     )
+    tb_options = {
+        "compile_inputs": runfiles_relative_short_path(ctx.outputs.compile_inputs),
+        "dut_instance": ctx.attr.dut_instance,
+        "dut_top": ctx.attr.dut_top,
+    }
+    tb_options.update(backend.tb_options(ctx, extra_compile_outputs, xcelium_covfile))
     ctx.actions.write(
         output = ctx.outputs.tb_options,
-        content = str({
-            "compile_inputs": runfiles_relative_short_path(ctx.outputs.compile_inputs),
-            "dut_instance": ctx.attr.dut_instance,
-            "dut_top": ctx.attr.dut_top,
-            "vcs_cm_hier": runfiles_relative_short_path(ctx.file.vcs_cm_hier) if ctx.file.vcs_cm_hier else "",
-            "xcelium_covfile": runfiles_relative_short_path(xcelium_covfile) if xcelium_covfile else "",
-            "msie_primary_compile_args": runfiles_relative_short_path(extra_compile_outputs.primary_compile_args) if extra_compile_outputs.primary_compile_args else "",
-            "msie_incremental_compile_args": runfiles_relative_short_path(extra_compile_outputs.incremental_compile_args) if extra_compile_outputs.incremental_compile_args else "",
-            "msie_primary_inputs": runfiles_relative_short_path(extra_compile_outputs.primary_inputs) if extra_compile_outputs.primary_inputs else "",
-        }),
+        content = str(tb_options),
     )
 
     ctx.actions.write(
@@ -592,7 +609,14 @@ def _verilog_dv_tb_impl(ctx):
     )
 
     trans_srcs = get_transitive_srcs([], all_deps, VerilogInfo, "transitive_sources", allow_other_outputs = True)
-    trans_flists = get_transitive_srcs([], all_deps, VerilogInfo, "transitive_flists", allow_other_outputs = False)
+    trans_flists = get_transitive_srcs(
+        [],
+        all_deps,
+        VerilogInfo,
+        compile_config.flist_field,
+        allow_other_outputs = False,
+        fallback_attr_name = compile_config.fallback_flist_field,
+    )
     generated_outputs = [
         ctx.outputs.compile_args,
         ctx.outputs.compile_inputs,

--- a/verilog/private/rtl.bzl
+++ b/verilog/private/rtl.bzl
@@ -94,10 +94,6 @@ def create_flist_content(ctx, gumi_path, allow_library_discovery, makelib = ""):
     return flist_content
 
 def _verilog_rtl_library_impl(ctx):
-    if ctx.attr.no_synth:
-        fail(("{} sets no_synth=True, but rules_verilog has no synthesis consumer that can honor it. " +
-              "Filter this target in the synthesis rule instead.").format(ctx.label))
-
     srcs = ctx.files.headers + ctx.files.modules + ctx.files.lib_files + ctx.files.direct
 
     if ctx.attr.is_pkg:
@@ -164,6 +160,13 @@ def _verilog_rtl_library_impl(ctx):
         gumi_path = runfiles_relative_short_path(ctx.file.gumi_file_override)
 
     flist_content = create_flist_content(ctx, gumi_path = gumi_path, allow_library_discovery = False, makelib = ctx.attr.makelib)
+    vcs_flist = ctx.outputs.flist
+    if ctx.attr.makelib:
+        vcs_flist = ctx.actions.declare_file(ctx.label.name + "_vcs.f")
+        ctx.actions.write(
+            output = vcs_flist,
+            content = "\n".join(create_flist_content(ctx, gumi_path = gumi_path, allow_library_discovery = False)),
+        )
 
     last_module = None
     for m in ctx.files.modules:
@@ -180,11 +183,19 @@ def _verilog_rtl_library_impl(ctx):
 
     trans_srcs = get_transitive_srcs(srcs, ctx.attr.deps, VerilogInfo, "transitive_sources", allow_other_outputs = True)
     trans_flists = get_transitive_srcs([ctx.outputs.flist], ctx.attr.deps, VerilogInfo, "transitive_flists", allow_other_outputs = False)
+    trans_vcs_flists = get_transitive_srcs(
+        [vcs_flist],
+        ctx.attr.deps,
+        VerilogInfo,
+        "transitive_vcs_flists",
+        allow_other_outputs = False,
+        fallback_attr_name = "transitive_flists",
+    )
     trans_dpi = get_transitive_srcs([], ctx.attr.deps, VerilogInfo, "transitive_dpi", allow_other_outputs = False)
 
-    runfiles = ctx.runfiles(transitive_files = depset(transitive = [trans_srcs, trans_flists, trans_dpi]))
+    runfiles = ctx.runfiles(transitive_files = depset(transitive = [trans_srcs, trans_flists, trans_vcs_flists, trans_dpi]))
 
-    all_files = depset(transitive = [trans_srcs, trans_flists])
+    all_files = depset(transitive = [trans_srcs, trans_flists, trans_vcs_flists])
 
     return [
         ShellInfo(
@@ -195,6 +206,7 @@ def _verilog_rtl_library_impl(ctx):
         VerilogInfo(
             transitive_sources = trans_srcs,
             transitive_flists = trans_flists,
+            transitive_vcs_flists = trans_vcs_flists,
             transitive_dpi = trans_dpi,
             last_module = last_module,
         ),
@@ -236,7 +248,7 @@ verilog_rtl_library = rule(
         ),
         "no_synth": attr.bool(
             default = False,
-            doc = "Reserved compatibility attribute. Setting it to True fails analysis because this repository has no synthesis consumer that can honor it. Filter simulation-only targets in the synthesis rule instead.",
+            doc = "Compatibility marker for downstream synthesis aspects or consumers. Simulation targets continue to include this library.",
         ),
         "is_pkg": attr.bool(
             default = False,
@@ -268,8 +280,8 @@ verilog_rtl_library = rule(
         ),
         "makelib": attr.string(
             default = "",
-            doc = "Used to specify that this RTL lib should be compiled into its own library.\n" +
-                  "String value specified here is used as the name of the compile lib.",
+            doc = ("Compile this target into the named Xcelium library through -makelib/-endlib. " +
+                   "VCS receives the same ordered sources through a separate -file boundary; VCS recompilation isolation is provided by -Mupdate and Partition Compile rather than Xcelium library syntax."),
         ),
     },
     outputs = {
@@ -297,8 +309,8 @@ def verilog_rtl_pkg(
         See verilog_rtl_library::direct.
       no_synth: Default False.
 
-        Reserved for compatibility. True is rejected because this repository
-        cannot enforce synthesis filtering.
+        Compatibility marker for downstream synthesis aspects or consumers.
+        Simulation targets continue to include this package.
       deps: Other packages this target is dependent on.
 
         See verilog_rtl_library::deps.
@@ -539,7 +551,15 @@ def _verilog_rtl_lint_test_impl(ctx):
     else:
         fail("verilog_rtl_lint_test {} requires rulefile when simulator = 'XRUN'".format(ctx.label))
 
-    trans_flists = get_transitive_srcs([], ctx.attr.shells + ctx.attr.deps, VerilogInfo, "transitive_flists", allow_other_outputs = False)
+    flist_field = "transitive_vcs_flists" if simulator == "VCS" else "transitive_flists"
+    trans_flists = get_transitive_srcs(
+        [],
+        ctx.attr.shells + ctx.attr.deps,
+        VerilogInfo,
+        flist_field,
+        allow_other_outputs = False,
+        fallback_attr_name = "transitive_flists",
+    )
 
     # This is a workaround for an issue with using -define in Ascent and will be removed once the Ascent issue is fixed
     # See github issue #24
@@ -596,7 +616,14 @@ def _verilog_rtl_lint_test_impl(ctx):
         },
     )
 
-    trans_flists = get_transitive_srcs([], ctx.attr.shells + ctx.attr.deps, VerilogInfo, "transitive_flists", allow_other_outputs = False)
+    trans_flists = get_transitive_srcs(
+        [],
+        ctx.attr.shells + ctx.attr.deps,
+        VerilogInfo,
+        flist_field,
+        allow_other_outputs = False,
+        fallback_attr_name = "transitive_flists",
+    )
     trans_srcs = get_transitive_srcs([], ctx.attr.shells + ctx.attr.deps, VerilogInfo, "transitive_sources", allow_other_outputs = True)
 
     lint_runfile_targets = ctx.attr.shells + ctx.attr.deps + ctx.attr.design_info + [

--- a/verilog/private/simulators/vcs.bzl
+++ b/verilog/private/simulators/vcs.bzl
@@ -1,6 +1,6 @@
 """VCS backend helpers for DV rules."""
 
-load("//verilog/private:verilog.bzl", "VerilogInfo", "flists_to_arguments")
+load("//verilog/private:verilog.bzl", "VerilogInfo", "flists_to_arguments", "runfiles_relative_short_path")
 
 def _sanitize_defines(defines):
     sanitized = {}
@@ -40,7 +40,15 @@ def _compile_config(ctx, defines, compile_args):
     return struct(
         args = _sanitize_compile_args(compile_args),
         defines = "\n".join(["+define+{}{}".format(key, value) for key, value in _sanitize_defines(defines).items()]),
-        flists = flists_to_arguments(ctx.attr.shells + ctx.attr.deps, VerilogInfo, "transitive_flists", "\n-file"),
+        fallback_flist_field = "transitive_flists",
+        flist_field = "transitive_vcs_flists",
+        flists = flists_to_arguments(
+            ctx.attr.shells + ctx.attr.deps,
+            VerilogInfo,
+            "transitive_vcs_flists",
+            "\n-file",
+            fallback_field = "transitive_flists",
+        ),
         template = ctx.file._compile_args_template_vcs,
     )
 
@@ -66,10 +74,16 @@ def _runtime_config(ctx):
         template = ctx.file._default_sim_opts_vcs,
     )
 
+def _tb_options(ctx, unused_extra_compile_outputs, unused_xcelium_covfile):
+    return {
+        "vcs_cm_hier": runfiles_relative_short_path(ctx.file.vcs_cm_hier) if ctx.file.vcs_cm_hier else "",
+    }
+
 vcs_dv_backend = struct(
     compile_config = _compile_config,
     config_arg = _config_arg,
     extra_compile_outputs = _extra_compile_outputs,
     runtime_config = _runtime_config,
+    tb_options = _tb_options,
     validate_tb = _validate_tb,
 )

--- a/verilog/private/simulators/xcelium.bzl
+++ b/verilog/private/simulators/xcelium.bzl
@@ -1,6 +1,6 @@
 """Xcelium backend helpers for DV rules."""
 
-load("//verilog/private:verilog.bzl", "VerilogInfo", "flists_to_arguments", "verilog_input_inventory")
+load("//verilog/private:verilog.bzl", "VerilogInfo", "flists_to_arguments", "runfiles_relative_short_path", "verilog_input_inventory")
 
 def _validate_tb(ctx, has_msie_primary, has_msie_extras):
     if ctx.file.vcs_cm_hier:
@@ -15,6 +15,8 @@ def _compile_config(ctx, defines, compile_args):
     return struct(
         args = compile_args,
         defines = "\n".join(["-define {}{}".format(key, value) for key, value in defines.items()]),
+        fallback_flist_field = None,
+        flist_field = "transitive_flists",
         flists = flists_to_arguments(ctx.attr.deps + ctx.attr.shells, VerilogInfo, "transitive_flists", "\n-f"),
         template = ctx.file._compile_args_template_xrun,
     )
@@ -95,6 +97,14 @@ def _runtime_config(ctx):
         template = ctx.file._default_sim_opts_xrun,
     )
 
+def _tb_options(unused_ctx, extra_compile_outputs, xcelium_covfile):
+    return {
+        "msie_incremental_compile_args": runfiles_relative_short_path(extra_compile_outputs.incremental_compile_args) if extra_compile_outputs.incremental_compile_args else "",
+        "msie_primary_compile_args": runfiles_relative_short_path(extra_compile_outputs.primary_compile_args) if extra_compile_outputs.primary_compile_args else "",
+        "msie_primary_inputs": runfiles_relative_short_path(extra_compile_outputs.primary_inputs) if extra_compile_outputs.primary_inputs else "",
+        "xcelium_covfile": runfiles_relative_short_path(xcelium_covfile) if xcelium_covfile else "",
+    }
+
 def _unit_test_config(ctx, unit_test_template, default_sim_opts, simulator_command, filelist_flag, dpi_tool):
     return struct(
         default_sim_opts = default_sim_opts,
@@ -109,6 +119,7 @@ xcelium_dv_backend = struct(
     config_arg = _config_arg,
     extra_compile_outputs = _extra_compile_outputs,
     runtime_config = _runtime_config,
+    tb_options = _tb_options,
     unit_test_config = _unit_test_config,
     validate_tb = _validate_tb,
 )

--- a/verilog/private/verilog.bzl
+++ b/verilog/private/verilog.bzl
@@ -4,8 +4,9 @@
 CUSTOM_SHELL = "custom"
 
 VerilogInfo = provider("Transitive Verilog build inputs.", fields = {
-    "transitive_sources": "All source source files needed by a target. This flow is not currently setup to do partioned compile, so all files need to be carried through to the final step for compilation as a whole.",
+    "transitive_sources": "All source files needed by a target. They are retained for compile input tracking and simulator runfiles.",
     "transitive_flists": "All flists which specify ordering of transitive sources.",
+    "transitive_vcs_flists": "VCS-compatible flists. Source ordering and per-target filelist boundaries are preserved while Xcelium-only makelib markers are omitted.",
     "transitive_dpi": "Shared libraries (.so/.dll/.dylib) to link in via the DPI for testbenches.",
     "last_module": "This is a convenience accessor. The last module specified is assumed be the top module in a design. This is frequently needed by downstream tools.",
 })
@@ -45,7 +46,7 @@ def gather_shell_defines(shells):
         defines["gumi_use_{}".format(shell.label.name)] = ""
     return defines
 
-def get_transitive_srcs(srcs, deps, provider, attr_name, allow_other_outputs = False):
+def get_transitive_srcs(srcs, deps, provider, attr_name, allow_other_outputs = False, fallback_attr_name = None):
     """Obtain the source files for a target and its transitive dependencies.
 
     Args:
@@ -58,7 +59,12 @@ def get_transitive_srcs(srcs, deps, provider, attr_name, allow_other_outputs = F
     trans = []
     for dep in deps:
         if provider in dep:
-            trans.append(getattr(dep[provider], attr_name))
+            if hasattr(dep[provider], attr_name):
+                trans.append(getattr(dep[provider], attr_name))
+            elif fallback_attr_name and hasattr(dep[provider], fallback_attr_name):
+                trans.append(getattr(dep[provider], fallback_attr_name))
+            else:
+                fail("{} does not provide the required '{}' field".format(dep.label, attr_name))
         elif allow_other_outputs:
             trans.append(dep[DefaultInfo].files)
         else:
@@ -92,7 +98,7 @@ def merge_default_runfiles(ctx, files, targets, transitive_files = None):
         transitive_files = transitive_files,
     ).merge_all([target[DefaultInfo].default_runfiles for target in targets])
 
-def verilog_input_inventory(deps, extra_files):
+def verilog_input_inventory(deps, extra_files, flist_field = "transitive_flists", fallback_field = None):
     """Return a stable inventory of Verilog compile inputs.
 
     Args:
@@ -104,7 +110,14 @@ def verilog_input_inventory(deps, extra_files):
     """
     entries = []
     sources = get_transitive_srcs([], deps, VerilogInfo, "transitive_sources", allow_other_outputs = True)
-    flists = get_transitive_srcs([], deps, VerilogInfo, "transitive_flists", allow_other_outputs = False)
+    flists = get_transitive_srcs(
+        [],
+        deps,
+        VerilogInfo,
+        flist_field,
+        allow_other_outputs = False,
+        fallback_attr_name = fallback_field,
+    )
     for source in sources.to_list():
         entries.append("source\t{}".format(runfiles_relative_short_path(source)))
     for flist in flists.to_list():
@@ -113,14 +126,19 @@ def verilog_input_inventory(deps, extra_files):
         entries.append("runfile\t{}".format(runfiles_relative_short_path(extra_file)))
     return "\n".join(sorted(depset(entries).to_list())) + "\n"
 
-def flists_to_arguments(deps, provider, field, prefix, separator = "", tool_name = None, path_prefix = ""):
+def flists_to_arguments(deps, provider, field, prefix, separator = "", tool_name = None, path_prefix = "", fallback_field = None):
     # Emit Bazel short_path entries so generated filelists stay rooted at the
     # runfiles tree, e.g. hw/... and external/..., instead of machine-specific
     # absolute paths or fragile ../ relative traversals.
     transitive = []
     for dep in deps:
         if provider in dep:
-            transitive.append(getattr(dep[provider], field))
+            if hasattr(dep[provider], field):
+                transitive.append(getattr(dep[provider], field))
+            elif fallback_field and hasattr(dep[provider], fallback_field):
+                transitive.append(getattr(dep[provider], fallback_field))
+            else:
+                fail("{} does not provide the required '{}' field".format(dep.label, field))
 
         # else:
         #     trans.extend(dep[DefaultInfo].files.to_list())


### PR DESCRIPTION
## Summary
- remove the internal `@pip_deps` repository and let the consuming top-level project own Python dependencies
- preserve Xcelium `makelib` boundaries while generating a VCS-compatible companion filelist with the same ordered sources
- keep `no_synth=True` as a compatibility marker instead of rejecting simulation analysis
- emit simulator-specific testbench metadata and isolate VCS KDB partition databases by mode
- add entrypoint, dependency, filelist, runtime-contract, and documentation coverage

## Root causes fixed
- external users could not resolve the ruleset-owned `@pip_deps` repository
- Xcelium-only `makelib` tokens leaked into VCS source input
- `no_synth=True` caused analysis failures even for simulation consumers
- Xcelium MSIE options leaked into VCS testbench options
- wave and non-wave partition compiles could reuse incompatible KDB databases

## Validation
- `bazel test //:buildifier_diff //tests:docs_test //tests:external_python_deps_test //tests:simmer_entrypoint_test`
- focused VCS runtime contract tests for partition database ownership and KDB mode isolation
- focused VCS/Xcelium filelist tests for `no_synth`, `makelib`, `-file`, coverage, and MSIE behavior
- backend build targets for VCS, Xcelium, RTL lint, and makelib
- `git diff --check` and YAPF diff clean

The complete runtime-contract target still has six pre-existing Windows/POSIX portability failures involving Bash paths, temporary permissions, and slash direction; all changed runtime tests pass individually.