### PR TITLE
Enable VCS compile performance defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ to be available on `PATH`.
 
 ### VCS Partition Compile
 
-VCS uses regular incremental `-Mupdate` by default. Add `--vcs-partcomp` to one
-simmer command to enable Partition Compile. The writable partition database is
+VCS enables automatic compile fingerprint reuse and Partition Compile by
+default. An unchanged fingerprint bypasses VCS; a changed build uses the
+allocation-aware partition flow. The writable partition database is
 `<tb>__VCS_VCOMP/partitionlib`; `--waves` and `--gui` use sibling
 `partitionlib_waves` and `partitionlib_gui` databases so incompatible KDB
 options do not invalidate each other. Stable third-party IP/VIP
@@ -99,12 +100,14 @@ rebuilt. Tune parallel compilation after measuring the workstation:
 
 ```bash
 simmer -t 'sys_tb:smoke_test@1' --simulator VCS \
-  --vcs-partcomp --vcs-partcomp-jobs 16 --vcs-profile
+  --vcs-partcomp-jobs 16 --vcs-profile
 ```
 
-Omit `--vcs-partcomp` to use regular incremental compilation. Shared partition
-databases and the full compatibility guidance are documented in
-[VCS and Xcelium workflow](docs/simmer_vcs_xcelium.md#vcs-partition-compile).
+Use `--no-vcs-partcomp` for an unsupported VCS release or a regular `-Mupdate`
+comparison. Use `--no-vcs-auto-compile-cache` to invoke VCS even when the
+fingerprint matches. Shared partition databases and the full compatibility
+guidance are documented in [VCS and Xcelium
+workflow](docs/simmer_vcs_xcelium.md#vcs-partition-compile).
 
 ### VCS ICO and VSO.ai
 
@@ -114,7 +117,7 @@ ICO, VSO.ai CSO and VSO.ai Coverage Directed Solver are separate opt-in flows:
 simmer -t 'sys_tb:*@20' --simulator VCS --ico \
   --ico-shared-record /nfs/project/ico/shared_record
 
-simmer -t 'sys_tb:*@100' --simulator VCS --vso --vso-cbv --cm line \
+simmer -t 'sys_tb:*@100' --simulator VCS --vso --vso-cbv --vcs-cm line \
   --vso-dbdir /nfs/project/vso/model --vso-phase stress:3
 
 simmer -t 'sys_tb:*@20' --simulator VCS --vso-ccex \
@@ -172,7 +175,7 @@ Add simulator-specific coverage when coverage results should appear in the
 dashboard:
 
 ```bash
-simmer -t 'sys_tb:*@10' --simulator VCS --cm A \
+simmer -t 'sys_tb:*@10' --simulator VCS --vcs-cm A \
   --report --report-dir "$PWD/report-output"
 
 simmer -t 'sys_tb:*@10' --simulator XRUN --coverage A \

--- a/bin/args_parse/common.py
+++ b/bin/args_parse/common.py
@@ -11,6 +11,12 @@ _SIMRESULTS = os.path.expanduser(os.environ.get("SIMRESULTS") or os.path.join(_S
 REPORT_DIR = os.environ.get("SIMMER_REPORT_DIR", os.path.join(_SIMRESULTS, "webroot"))
 
 
+def add_child_argument(container, *args, parent, **kwargs):
+    action = container.add_argument(*args, **kwargs)
+    action.simmer_parent = parent
+    return action
+
+
 def add_debug_arguments(parser):
     gdebug = parser.add_argument_group(
         'Debug arguments',
@@ -22,32 +28,42 @@ def add_debug_arguments(parser):
         nargs='*',
         help=('Enable waveform capture. Optionally list HDL scopes after the option; with no scopes, '
               'the simulator adapter uses its default top. Quote wildcard scopes so the shell does not expand them.'))
-    gdebug.add_argument('--wave-type',
-                        type=str,
-                        default=None,
-                        choices=['shm', 'fsdb', 'vcd', 'vwdb'],
-                        help=('Select the waveform database format. Defaults to fsdb for VCS and vwdb for XRUN; '
-                              'VCS accepts fsdb, while XRUN accepts shm, vcd, or vwdb. Requires --waves.'))
-    gdebug.add_argument('--wave-tcl',
-                        type=str,
-                        default=None,
-                        help=('Use an existing simulator-specific wave/probe Tcl file instead of generated commands. '
-                              'The file must exist and is used only when waveform capture is enabled.'))
-    gdebug.add_argument(
+    add_child_argument(gdebug,
+                       '--wave-type',
+                       parent='--waves',
+                       type=str,
+                       default=None,
+                       choices=['shm', 'fsdb', 'vcd', 'vwdb'],
+                       help=('Select the waveform database format. Defaults to fsdb for VCS and vwdb for XRUN; '
+                             'VCS accepts fsdb, while XRUN accepts shm, vcd, or vwdb. Requires --waves.'))
+    add_child_argument(gdebug,
+                       '--wave-tcl',
+                       parent='--waves',
+                       type=str,
+                       default=None,
+                       help=('Use an existing simulator-specific wave/probe Tcl file instead of generated commands. '
+                             'The file must exist and is used only when waveform capture is enabled.'))
+    add_child_argument(
+        gdebug,
         '--wave-start',
+        parent='--waves',
         type=int,
         default=0,
         help='Start waveform dumping at this non-negative simulation time in ns (default: 0). Requires --waves.')
-    gdebug.add_argument('--wave-end',
-                        type=int,
-                        default=99999999,
-                        help=('Stop waveform dumping at this simulation time in ns (default: effectively unlimited). '
-                              'It must be greater than --wave-start. Requires --waves.'))
-    gdebug.add_argument('--wave-depth',
-                        type=int,
-                        default=999,
-                        help=('Set generated probe hierarchy depth (default: 999, effectively all hierarchy). '
-                              'Reduce it to limit waveform size. Requires --waves.'))
+    add_child_argument(gdebug,
+                       '--wave-end',
+                       parent='--waves',
+                       type=int,
+                       default=99999999,
+                       help=('Stop waveform dumping at this simulation time in ns (default: effectively unlimited). '
+                             'It must be greater than --wave-start. Requires --waves.'))
+    add_child_argument(gdebug,
+                       '--wave-depth',
+                       parent='--waves',
+                       type=int,
+                       default=999,
+                       help=('Set generated probe hierarchy depth (default: 999, effectively all hierarchy). '
+                             'Reduce it to limit waveform size. Requires --waves.'))
     gdebug.add_argument('--verbosity',
                         type=str,
                         default=None,
@@ -168,9 +184,8 @@ def add_test_configuration_arguments(parser):
                         default=None,
                         action=parser_actions.XpropAction,
                         help=('Opt-in X-propagation selector. F=more pessimistic mode, C=ternary-like mode, D=Disable. '
-                              'On Xcelium, F maps to FOX and C maps to CAT. '
-                              'On VCS, F falls back to -xprop=xmerge and C falls back to -xprop=tmerge '
-                              'when no VCS xprop config file is present.'))
+                              'On Xcelium, F maps to FOX and C maps to CAT. For VCS, prefer --vcs-xprop; this '
+                              'shared spelling remains compatible.'))
     gtestc.add_argument('--timeout',
                         default=12.0,
                         type=float,
@@ -234,11 +249,6 @@ def add_regression_arguments(parser):
 def add_flow_control_arguments(parser):
     gflowc = parser.add_argument_group("Flow control arguments",
                                        "Control which build, compile, run, and report phases execute.")
-    gflowc.add_argument(
-        '--lmstat',
-        default=False,
-        action="store_true",
-        help='Run lmstat -a before scheduling jobs and save the output. Requires lmstat on PATH and license access.')
     gflowc.add_argument('--no-run',
                         default=False,
                         action="store_true",

--- a/bin/args_parse/parser.py
+++ b/bin/args_parse/parser.py
@@ -54,6 +54,15 @@ class SimmerHelpFormatter(argparse.HelpFormatter):
         return '\n'.join(indent + line for source_line in text.splitlines()
                          for line in self._wrap_line(source_line, width))
 
+    def _format_action(self, action):
+        if not getattr(action, 'simmer_parent', None):
+            return super()._format_action(action)
+        self._current_indent += 2
+        try:
+            return super()._format_action(action)
+        finally:
+            self._current_indent -= 2
+
 
 def reproduction_args(argv):
     """Keep original options except selectors replaced by rerun.sh."""
@@ -110,7 +119,8 @@ def parse_args(argv):
     if options.history is not None and options.history < 1:
         parser.error("--history must be a positive integer.")
     options.simulator_was_explicit = simulator_explicitly_requested(argv)
-    options.xprop_was_explicit = argument_explicitly_requested(argv, '--xprop')
+    options.xprop_was_explicit = any(
+        argument_explicitly_requested(argv, argument) for argument in ('--xprop', '--vcs-xprop'))
     options.timeout_was_explicit = argument_explicitly_requested(argv, '--timeout')
     options.covfile_was_explicit = argument_explicitly_requested(argv, '--covfile')
     options.mce_detail_was_explicit = any(
@@ -147,6 +157,7 @@ def parse_args(argv):
     ]
     options.vcs_explicit_switches = [
         argument for argument in [
+            '--vcs-cm',
             '--cm',
             '--gui',
             '--vcs-cm-line',
@@ -158,15 +169,18 @@ def parse_args(argv):
             '--vcs-urg-parallel',
             '--vcs-urg-show-tests',
             '--vcs-partcomp',
+            '--no-vcs-partcomp',
             '--vcs-partcomp-mode',
             '--vcs-partcomp-jobs',
             '--vcs-partcomp-dir',
             '--vcs-partcomp-sharedlib',
             '--vcs-auto-compile-cache',
+            '--no-vcs-auto-compile-cache',
             '--smartlog',
             '--vcs-runner',
             '--dtl',
             '--fgp',
+            '--vcs-xprop',
             '--vcs-xprop-flowctrl',
             '--vcs-xprop-mmsopt',
             '--vcs-xprop-banner',

--- a/bin/args_parse/vcs.py
+++ b/bin/args_parse/vcs.py
@@ -2,6 +2,8 @@ import argparse
 
 from lib import parser_actions
 
+from .common import add_child_argument
+
 
 def _partcomp_jobs(value):
     if str(value).lower() == 'auto':
@@ -24,92 +26,136 @@ def add_vcs_arguments(parser):
         action='store_true',
         help=('Compile one selected test with Verdi debug access and launch simv in the Verdi GUI.\n'
               'Preparation: select exactly one VCS test and ensure a Verdi license/display is available.'))
-    gvcs.add_argument('--cm',
+    gvcs.add_argument('--vcs-cm',
+                      dest='cm',
                       action=parser_actions.CMAction,
                       help=(f'Enable VCS compile/runtime coverage and generate the URG/Verdi merge flow.\n'
                             f'Use A for all supported metrics or join individual metrics with +.\n'
                             f'{parser_actions.CMAction.format_options(indent=0)}'))
-    gvcs.add_argument('--vcs-cm-line',
-                      type=str,
-                      default=None,
-                      choices=['contassign', 'svtb', 'svtb+svtb_include_lib'],
-                      help=('Pass -cm_line MODE to VCS. Requires --cm line or --cm A; use svtb modes only when '
-                            'testbench line coverage is intentionally included.'))
-    gvcs.add_argument('--vcs-cm-report',
-                      action='append',
-                      default=None,
-                      choices=['svpackages', 'noinitial'],
-                      help=('Pass one -cm_report mode to VCS; repeat for both. svpackages includes SystemVerilog '
-                            'packages and requires line coverage. noinitial excludes initial blocks from line, '
-                            'condition, and branch coverage.'))
-    gvcs.add_argument('--vcs-cm-cond',
-                      type=str,
-                      default=None,
-                      help=('Pass a plus-separated -cm_cond mode list, for example obs+event as recommended for '
-                            'observable conditions and sensitivity lists. Requires --cm cond or --cm A.'))
-    gvcs.add_argument('--vcs-cm-tgl',
-                      type=str,
-                      default=None,
-                      help=('Pass a plus-separated -cm_tgl mode list, for example portsonly or mda. Requires '
-                            '--cm tgl or --cm A; portsonly reduces toggle coverage cost to design ports.'))
-    gvcs.add_argument('--vcs-cm-hier',
-                      type=str,
-                      default=None,
-                      help=('Pass an existing -cm_hier configuration file to VCS. Requires --cm; the path is '
-                            'validated before Bazel starts and overrides the testbench vcs_cm_hier setting.'))
+    add_child_argument(gvcs,
+                       '--vcs-cm-line',
+                       parent='--vcs-cm',
+                       type=str,
+                       default=None,
+                       choices=['contassign', 'svtb', 'svtb+svtb_include_lib'],
+                       help=('Pass -cm_line MODE to VCS. Requires --vcs-cm line or --vcs-cm A; use svtb modes only '
+                             'when testbench line coverage is intentionally included.'))
+    add_child_argument(gvcs,
+                       '--vcs-cm-report',
+                       parent='--vcs-cm',
+                       action='append',
+                       default=None,
+                       choices=['svpackages', 'noinitial'],
+                       help=('Pass one -cm_report mode to VCS; repeat for both. svpackages includes SystemVerilog '
+                             'packages and requires line coverage. noinitial excludes initial blocks from line, '
+                             'condition, and branch coverage.'))
+    add_child_argument(gvcs,
+                       '--vcs-cm-cond',
+                       parent='--vcs-cm',
+                       type=str,
+                       default=None,
+                       help=('Pass a plus-separated -cm_cond mode list, for example obs+event as recommended for '
+                             'observable conditions and sensitivity lists. Requires --vcs-cm cond or --vcs-cm A.'))
+    add_child_argument(gvcs,
+                       '--vcs-cm-tgl',
+                       parent='--vcs-cm',
+                       type=str,
+                       default=None,
+                       help=('Pass a plus-separated -cm_tgl mode list, for example portsonly or mda. Requires '
+                             '--vcs-cm tgl or --vcs-cm A; portsonly reduces toggle coverage cost to design ports.'))
+    add_child_argument(gvcs,
+                       '--vcs-cm-hier',
+                       parent='--vcs-cm',
+                       type=str,
+                       default=None,
+                       help=('Pass an existing -cm_hier configuration file to VCS. Requires --vcs-cm; the path is '
+                             'validated before Bazel starts and overrides the testbench vcs_cm_hier setting.'))
+    add_child_argument(gvcs,
+                       '--vcs-urg-parallel',
+                       parent='--vcs-cm',
+                       default=False,
+                       action='store_true',
+                       help=('Add -parallel to the generated URG coverage merge. Enable only after measuring local '
+                             'CPU and memory use or configuring the site grid options outside simmer.'))
+    add_child_argument(gvcs,
+                       '--vcs-urg-show-tests',
+                       parent='--vcs-cm',
+                       default=False,
+                       action='store_true',
+                       help=('Add -show tests to the generated URG merge so the merged VDB retains test-to-cover '
+                             'correlation for grading and debug. This increases merged database size.'))
+    add_child_argument(gvcs,
+                       '--cm',
+                       parent='--vcs-cm',
+                       dest='cm',
+                       default=argparse.SUPPRESS,
+                       action=parser_actions.CMAction,
+                       help='Compatibility alias for --vcs-cm.')
     gvcs.add_argument('--vcs-profile',
                       default=False,
                       action='store_true',
                       help=('Add -pcmakeprof -reportstats and write phase/partition timing statistics to cmp.log. '
                             'Use this when comparing scratch, incremental, or Partition Compile performance.'))
-    gvcs.add_argument('--vcs-urg-parallel',
-                      default=False,
-                      action='store_true',
-                      help=('Add -parallel to the generated URG coverage merge. Enable only after measuring local '
-                            'CPU and memory use or configuring the site grid options outside simmer.'))
-    gvcs.add_argument('--vcs-urg-show-tests',
-                      default=False,
-                      action='store_true',
-                      help=('Add -show tests to the generated URG merge so the merged VDB retains test-to-cover '
-                            'correlation for grading and debug. This increases merged database size.'))
-    gvcs.add_argument(
+    partcomp_control = gvcs.add_mutually_exclusive_group()
+    partcomp_control.add_argument(
         '--vcs-partcomp',
-        default=False,
+        dest='vcs_partcomp',
         action='store_true',
-        help=('Enable VCS Partition Compile for this simmer invocation (default: disabled; regular -Mupdate only).\n'
-              'This is the only switch that enables Partition Compile; use the --vcs-partcomp-* options below to '
-              'tune the enabled flow.'))
-    gvcs.add_argument('--vcs-partcomp-mode',
-                      default='auto',
-                      choices=['adaptive', 'auto', 'low', 'high', 'relax'],
-                      help=('Select VCS Partition Compile behavior after --vcs-partcomp (default when enabled: auto).\n'
-                            'adaptive: schedule partitions using current load; auto: standard autopartitioning;\n'
-                            'low: more/smaller partitions; high: fewer/larger partitions;\n'
-                            'relax: relax a poorly balanced high-threshold result.'))
-    gvcs.add_argument('--vcs-partcomp-jobs',
-                      default='auto',
-                      type=_partcomp_jobs,
-                      help=('Maximum parallel partition compile processes passed as -fastpartcomp=jN (default: auto). '
-                            'auto uses CPUs allocated to this job by LSF/Slurm or process affinity; it never scans '
-                            'cluster idle CPUs. Requires --vcs-partcomp.'))
-    gvcs.add_argument('--vcs-partcomp-dir',
-                      default=None,
-                      help=('Override the writable -partcomp_dir. The default is '
-                            '<regression>/<tb>__VCS_VCOMP/partitionlib and is removed by --recompile. '
-                            'Use a versioned external path only when intentionally publishing a baseline. '
-                            'Requires --vcs-partcomp.'))
-    gvcs.add_argument('--vcs-partcomp-sharedlib',
-                      default=None,
-                      help=('Reuse an existing partition database through -partcomp_sharedlib. The directory must '
-                            'already exist, must differ from --vcs-partcomp-dir, and must match the VCS version, '
-                            'Red Hat platform, source inventory, defines, coverage/debug mode, and compile arguments. '
-                            'Requires --vcs-partcomp.'))
-    gvcs.add_argument(
+        help=('Keep VCS Partition Compile enabled (default). The --vcs-partcomp-* options tune the enabled flow; '
+              'use --no-vcs-partcomp for unsupported VCS releases or diagnostics.'))
+    partcomp_control.add_argument('--no-vcs-partcomp',
+                                  dest='vcs_partcomp',
+                                  action='store_false',
+                                  help=('Disable VCS Partition Compile and use regular -Mupdate only. Use this for '
+                                        'unsupported VCS releases or direct incremental-compile comparisons.'))
+    gvcs.set_defaults(vcs_partcomp=True)
+    add_child_argument(gvcs,
+                       '--vcs-partcomp-mode',
+                       parent='--vcs-partcomp',
+                       default='auto',
+                       choices=['adaptive', 'auto', 'low', 'high', 'relax'],
+                       help=('Select VCS Partition Compile behavior while it is enabled (default: auto).\n'
+                             'adaptive: schedule partitions using current load; auto: standard autopartitioning;\n'
+                             'low: more/smaller partitions; high: fewer/larger partitions;\n'
+                             'relax: relax a poorly balanced high-threshold result.'))
+    add_child_argument(gvcs,
+                       '--vcs-partcomp-jobs',
+                       parent='--vcs-partcomp',
+                       default='auto',
+                       type=_partcomp_jobs,
+                       help=('Maximum parallel partition compile processes passed as -fastpartcomp=jN (default: auto). '
+                             'auto uses CPUs allocated to this job by LSF/Slurm or process affinity; it never scans '
+                             'cluster idle CPUs. Cannot be combined with --no-vcs-partcomp.'))
+    add_child_argument(gvcs,
+                       '--vcs-partcomp-dir',
+                       parent='--vcs-partcomp',
+                       default=None,
+                       help=('Override the writable -partcomp_dir. The default is '
+                             '<regression>/<tb>__VCS_VCOMP/partitionlib and is removed by --recompile. '
+                             'Use a versioned external path only when intentionally publishing a baseline. '
+                             'Cannot be combined with --no-vcs-partcomp.'))
+    add_child_argument(gvcs,
+                       '--vcs-partcomp-sharedlib',
+                       parent='--vcs-partcomp',
+                       default=None,
+                       help=('Reuse an existing partition database through -partcomp_sharedlib. The directory must '
+                             'already exist, must differ from --vcs-partcomp-dir, and must match the VCS version, '
+                             'Red Hat platform, source inventory, defines, coverage/debug mode, and compile arguments. '
+                             'Cannot be combined with --no-vcs-partcomp.'))
+    compile_cache_control = gvcs.add_mutually_exclusive_group()
+    compile_cache_control.add_argument(
         '--vcs-auto-compile-cache',
-        default=False,
+        dest='vcs_auto_compile_cache',
         action='store_true',
-        help=('Automatically skip VCS compilation when the existing simv and compile fingerprint are unchanged. '
-              'Unlike --no-compile, a cache miss recompiles normally. Cannot be combined with --recompile.'))
+        help=('Keep automatic VCS compile reuse enabled (default). A matching fingerprint and simv bypass VCS; a '
+              'miss compiles normally. --recompile and --no-compile take precedence for their invocation.'))
+    compile_cache_control.add_argument(
+        '--no-vcs-auto-compile-cache',
+        dest='vcs_auto_compile_cache',
+        action='store_false',
+        help=('Disable automatic compile bypass and always invoke VCS, allowing -Mupdate or Partition Compile to '
+              'decide what to rebuild. Use this for incremental compiler diagnostics.'))
+    gvcs.set_defaults(vcs_auto_compile_cache=True)
     gvcs.add_argument('--smartlog',
                       dest='smartlog',
                       default=False,
@@ -124,93 +170,129 @@ def add_vcs_arguments(parser):
     gvcs.add_argument('--dtl',
                       default=False,
                       action='store_true',
-                      help=('Enable the batch-only VCS Dynamic Test Loading static/base compile flow. It requires '
-                            '--vcs-partcomp, owns <VCOMP>/dtl_static, and cannot be combined with --gui or custom '
-                            'Partition Compile mode/directories.'))
+                      help=('Enable the batch-only VCS Dynamic Test Loading static/base compile flow. It uses the '
+                            'default Partition Compile flow, owns <VCOMP>/dtl_static, and cannot be combined with '
+                            '--no-vcs-partcomp, --gui, or custom Partition Compile mode/directories.'))
     gvcs.add_argument('--fgp',
                       type=int,
                       default=None,
                       help=('Enable VCS Fine-Grained Parallelism at compile time and pass -fgp=num_threads:N '
                             'at runtime. N must be positive; simmer reduces concurrent test jobs to account for it.'))
-    gvcs.add_argument('--vcs-xprop-flowctrl',
-                      default=False,
-                      action='store_true',
-                      help='Add VCS -xprop=flowctrl. Requires --xprop F or --xprop C; use only after xprop profiling.')
-    gvcs.add_argument('--vcs-xprop-mmsopt',
-                      default=False,
-                      action='store_true',
-                      help='Add VCS -xprop=mmsopt. Requires --xprop F or --xprop C; use only after xprop profiling.')
-    gvcs.add_argument('--vcs-xprop-banner',
-                      default=False,
-                      action='store_true',
-                      help='Add runtime -xprop=banner. Requires --xprop F or --xprop C.')
-    gvcs.add_argument('--vcs-xprop-report',
-                      default=False,
-                      action='store_true',
-                      help='Add runtime -report=xprop. Requires --xprop F or --xprop C.')
+    gvcs.add_argument('--vcs-xprop',
+                      dest='xprop',
+                      default=argparse.SUPPRESS,
+                      action=parser_actions.XpropAction,
+                      help=('Enable VCS X-propagation. F uses xmerge and C uses tmerge when no bench config exists; '
+                            'D disables it. The shared --xprop spelling remains available for compatibility.'))
+    add_child_argument(gvcs,
+                       '--vcs-xprop-flowctrl',
+                       parent='--vcs-xprop',
+                       default=False,
+                       action='store_true',
+                       help=('Add VCS -xprop=flowctrl. Requires --vcs-xprop F or --vcs-xprop C; use only after '
+                             'xprop profiling.'))
+    add_child_argument(gvcs,
+                       '--vcs-xprop-mmsopt',
+                       parent='--vcs-xprop',
+                       default=False,
+                       action='store_true',
+                       help=('Add VCS -xprop=mmsopt. Requires --vcs-xprop F or --vcs-xprop C; use only after '
+                             'xprop profiling.'))
+    add_child_argument(gvcs,
+                       '--vcs-xprop-banner',
+                       parent='--vcs-xprop',
+                       default=False,
+                       action='store_true',
+                       help='Add runtime -xprop=banner. Requires --vcs-xprop F or --vcs-xprop C.')
+    add_child_argument(gvcs,
+                       '--vcs-xprop-report',
+                       parent='--vcs-xprop',
+                       default=False,
+                       action='store_true',
+                       help='Add runtime -report=xprop. Requires --vcs-xprop F or --vcs-xprop C.')
     gvcs.add_argument('--ico',
                       default=False,
                       action='store_true',
                       help=('Enable VCS ICO shared-regression mode: initialize a shared CDB with crg and pass the '
                             'recommended ICO auto-configuration runtime options to each simv.'))
-    gvcs.add_argument('--ico-workdir',
-                      type=str,
-                      default=None,
-                      help=('Override the VCS ICO local work directory. Requires --ico; default is '
-                            '<regression>/ico_artifacts/workdir.'))
-    gvcs.add_argument('--ico-shared-record',
-                      type=str,
-                      default=None,
-                      help=('Override the VCS ICO shared CDB directory. Requires --ico; default is '
-                            '<regression>/ico_artifacts/shared_record. An initialized CDB is reused.'))
+    add_child_argument(gvcs,
+                       '--ico-workdir',
+                       parent='--ico',
+                       type=str,
+                       default=None,
+                       help=('Override the VCS ICO local work directory. Requires --ico; default is '
+                             '<regression>/ico_artifacts/workdir.'))
+    add_child_argument(gvcs,
+                       '--ico-shared-record',
+                       parent='--ico',
+                       type=str,
+                       default=None,
+                       help=('Override the VCS ICO shared CDB directory. Requires --ico; default is '
+                             '<regression>/ico_artifacts/shared_record. An initialized CDB is reused.'))
     gvcs.add_argument('--vso',
                       default=False,
                       action='store_true',
                       help=('Enable the VSO.ai CSO three-step flow: compile each build with -vso cso, run driver '
                             'init/ask-all, execute selected tests with run IDs, then finalize/merge with bulk status.'))
-    gvcs.add_argument('--vso-workdir',
-                      type=str,
-                      default=None,
-                      help=('Override the VSO.ai per-regression workdir. Requires --vso; default is '
-                            '<regression>/vso_artifacts/workdir. All VSO steps and simv jobs must access it.'))
-    gvcs.add_argument('--vso-dbdir',
-                      type=str,
-                      default=None,
-                      help=('Select the persistent VSO.ai learning dbdir. Requires --vso; default is an empty '
-                            '<regression>/vso_artifacts/dbdir suitable for a Day0 run.'))
-    gvcs.add_argument('--vso-buildname',
-                      type=str,
-                      default=None,
-                      help=('Override the VSO.ai build name for a single selected VCS build. Requires --vso; '
-                            'otherwise each VCOMP job name is used as its unique build name.'))
-    gvcs.add_argument('--vso-target-metric',
-                      type=str,
-                      default=None,
-                      help=('Set the comma-separated VSO.ai target metrics: all, assert, cond, fsm, group, line, '
-                            'or tgl. Requires --vso; otherwise metrics are derived from --cm.'))
-    gvcs.add_argument('--vso-phase',
-                      action='append',
-                      default=None,
-                      help=('Pass one VSO.ai init phase selection, such as stress, stress:3, acceleration, or '
-                            'exploration. Repeat the option for multiple phases. Requires --vso.'))
-    gvcs.add_argument('--vso-cbv',
-                      default=False,
-                      action='store_true',
-                      help=('Enable VSO.ai Change-Based Verification compile tagging by passing the CSO workdir '
-                            'to VCS. Requires --vso and Day0 line coverage or port-only toggle coverage.'))
+    add_child_argument(gvcs,
+                       '--vso-workdir',
+                       parent='--vso',
+                       type=str,
+                       default=None,
+                       help=('Override the VSO.ai per-regression workdir. Requires --vso; default is '
+                             '<regression>/vso_artifacts/workdir. All VSO steps and simv jobs must access it.'))
+    add_child_argument(gvcs,
+                       '--vso-dbdir',
+                       parent='--vso',
+                       type=str,
+                       default=None,
+                       help=('Select the persistent VSO.ai learning dbdir. Requires --vso; default is an empty '
+                             '<regression>/vso_artifacts/dbdir suitable for a Day0 run.'))
+    add_child_argument(gvcs,
+                       '--vso-buildname',
+                       parent='--vso',
+                       type=str,
+                       default=None,
+                       help=('Override the VSO.ai build name for a single selected VCS build. Requires --vso; '
+                             'otherwise each VCOMP job name is used as its unique build name.'))
+    add_child_argument(gvcs,
+                       '--vso-target-metric',
+                       parent='--vso',
+                       type=str,
+                       default=None,
+                       help=('Set the comma-separated VSO.ai target metrics: all, assert, cond, fsm, group, line, '
+                             'or tgl. Requires --vso; otherwise metrics are derived from --vcs-cm.'))
+    add_child_argument(gvcs,
+                       '--vso-phase',
+                       parent='--vso',
+                       action='append',
+                       default=None,
+                       help=('Pass one VSO.ai init phase selection, such as stress, stress:3, acceleration, or '
+                             'exploration. Repeat the option for multiple phases. Requires --vso.'))
+    add_child_argument(gvcs,
+                       '--vso-cbv',
+                       parent='--vso',
+                       default=False,
+                       action='store_true',
+                       help=('Enable VSO.ai Change-Based Verification compile tagging by passing the CSO workdir '
+                             'to VCS. Requires --vso and Day0 line coverage or port-only toggle coverage.'))
     gvcs.add_argument('--vso-ccex',
                       default=False,
                       action='store_true',
                       help=('Enable the VSO.ai LCA Coverage Directed Solver by passing -vso ccex at VCS compile '
                             'and simv runtime. Put extra compile options in --file and runtime -ccex_opts values '
                             'in --sim-opts-file.'))
-    gvcs.add_argument('--vso-ccex-rca',
-                      default=False,
-                      action='store_true',
-                      help=('Enable Coverage Directed Solver static root-cause analysis with -ccex_opts rca. '
-                            'Requires --vso-ccex; inspect results with an URG or Verdi CCEX report.'))
-    gvcs.add_argument('--vso-ccex-auto-merge-dir',
-                      type=str,
-                      default=None,
-                      help=('Enable inter-simulation Coverage Directed Solver learning through the given shared '
-                            'directory. Requires --vso-ccex and storage visible to every simv job.'))
+    add_child_argument(gvcs,
+                       '--vso-ccex-rca',
+                       parent='--vso-ccex',
+                       default=False,
+                       action='store_true',
+                       help=('Enable Coverage Directed Solver static root-cause analysis with -ccex_opts rca. '
+                             'Requires --vso-ccex; inspect results with an URG or Verdi CCEX report.'))
+    add_child_argument(gvcs,
+                       '--vso-ccex-auto-merge-dir',
+                       parent='--vso-ccex',
+                       type=str,
+                       default=None,
+                       help=('Enable inter-simulation Coverage Directed Solver learning through the given shared '
+                             'directory. Requires --vso-ccex and storage visible to every simv job.'))

--- a/bin/args_parse/xcelium.py
+++ b/bin/args_parse/xcelium.py
@@ -1,6 +1,6 @@
 from lib import parser_actions
 
-from .common import COVFILE
+from .common import COVFILE, add_child_argument
 
 
 def add_xcelium_arguments(parser):
@@ -34,28 +34,38 @@ def add_xcelium_arguments(parser):
         action='store_true',
         help=('Enable XRUN Multicore Engine for compile and simulation. Requires MCE licenses; xprop is ignored and '
               'MSIE or emulator modes are rejected.'))
-    gxrun.add_argument('--mce-build-count',
+    add_child_argument(gxrun,
+                       '--mce-build-count',
+                       parent='--mce',
                        type=int,
                        default=4,
                        help=('Set XRUN MCE build thread count (default: 4; 0 lets XRUN use the configuration range). '
                              'Requires --mce.'))
-    gxrun.add_argument('--mce-build-cfg',
+    add_child_argument(gxrun,
+                       '--mce-build-cfg',
+                       parent='--mce',
                        type=str,
                        default='single-socket',
                        choices=['single-socket', 'all-cores'],
                        help='Select the XRUN MCE build CPU topology (default: single-socket). Requires --mce.')
-    gxrun.add_argument(
+    add_child_argument(
+        gxrun,
         '--mce-sim-count',
+        parent='--mce',
         type=int,
         default=4,
         help=('Set XRUN MCE simulation thread count (default: 4; 0 lets XRUN use the configuration range). '
               'Requires --mce; simmer adjusts job concurrency for this count.'))
-    gxrun.add_argument('--mce-sim-cfg',
+    add_child_argument(gxrun,
+                       '--mce-sim-cfg',
+                       parent='--mce',
                        type=str,
                        default='single-socket',
                        choices=['single-socket', 'single-threaded', 'partial-socket', 'all-cores'],
                        help='Select the XRUN MCE simulation CPU topology (default: single-socket). Requires --mce.')
-    gxrun.add_argument('--mce-split-max-size',
+    add_child_argument(gxrun,
+                       '--mce-split-max-size',
+                       parent='--mce',
                        type=int,
                        default=500000,
                        help='Set the positive XRUN MCE partition split-size limit (default: 500000). Requires --mce.')
@@ -64,8 +74,10 @@ def add_xcelium_arguments(parser):
                        help=(f'Enable XRUN coverage collection and generate the IMC merge/report flow.\n'
                              f'Use A for all metrics or join metrics with a colon, for example B:E:F:T:U.\n'
                              f'{parser_actions.CovAction.format_options(indent=0)}'))
-    gxrun.add_argument(
+    add_child_argument(
+        gxrun,
         '--covfile',
+        parent='--coverage',
         default=COVFILE,
         help=('Pass an existing Xcelium coverage configuration file. An explicitly supplied path requires '
               '--coverage and is validated before Bazel starts; otherwise the testbench xcelium_covfile is preferred.'))
@@ -96,18 +108,24 @@ def add_xcelium_arguments(parser):
         help=('Run the final multi-step MSIE stage and simulations against PRIMARY_SNAPSHOT. Preparation: configure '
               'verilog_dv_tb.msie_incremental_deps and complete matching href/primary stages in the same regression '
               'directory. Simmer validates the primary manifest before XRUN starts.'))
-    gxrun.add_argument(
+    add_child_argument(
+        gxrun,
         '--msie-primary-name',
+        parent='--msie-prim',
         metavar='SNAPSHOT',
         help=('Name the snapshot created by --msie-prim independently from its HDL top. Use the same value as the '
               'later --msie-incr argument; for example, top dut with snapshot dut_sdf_wc.'))
-    gxrun.add_argument(
+    add_child_argument(
+        gxrun,
         '--msie-primary-top',
+        parent='--msie-incr',
         metavar='PRIMARY_TOP',
         help=('Override the primary HDL top expected by --msie-incr. The default is the selected verilog_dv_tb '
               'dut_top value; set this only when the primary build used a different top.'))
-    gxrun.add_argument(
+    add_child_argument(
+        gxrun,
         '--msie-primary-key',
+        parent='--msie-prim/--msie-incr',
         metavar='KEY',
         default='',
         help=('Add an immutable site key to the primary compatibility manifest for --msie-prim/--msie-incr. Include '

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -259,12 +259,6 @@ class VCompJob(Job):
 
         log.debug("workdir = %s", self.job_dir)
 
-        if options.lmstat:
-            with open("lmstat.out", "w") as lmstat_out:
-                subprocess.run(["lmstat", "-a"], stdout=lmstat_out, stderr=subprocess.STDOUT, check=False)
-        else:
-            log.debug("Skipping lmstat -a")
-
         with open(os.path.join(self.job_dir, 'env.out'), 'w') as env_out:
             for key in ENV_CAPTURE_KEYS:
                 if key in os.environ:

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -72,9 +72,9 @@ simmer -t 'sys_tb:smoke_test@1' --simulator XRUN --waves hdl_top.dut --wave-type
 Coverage and reports:
 
 ```bash
-simmer -t 'sys_tb:*@10' --simulator VCS --cm line+cond+fsm \
+simmer -t 'sys_tb:*@10' --simulator VCS --vcs-cm line+cond+fsm \
   --vcs-cm-cond obs+event --vcs-urg-parallel --report
-simmer -t 'sys_tb:*@10' --simulator VCS --cm tgl \
+simmer -t 'sys_tb:*@10' --simulator VCS --vcs-cm tgl \
   --vcs-cm-tgl portsonly --vcs-urg-show-tests --report
 simmer -t 'sys_tb:*@10' --simulator XRUN --coverage A --report
 ```
@@ -87,11 +87,11 @@ simmer -t 'sys_tb:*@20' --simulator VCS --ico \
   --ico-shared-record /nfs/project/ico/shared_record
 
 # VSO.ai simplified CSO init/ask-all/execute/finalize+merge flow.
-simmer -t 'sys_tb:*@100' --simulator VCS --vso --cm A \
+simmer -t 'sys_tb:*@100' --simulator VCS --vso --vcs-cm A \
   --vso-dbdir /nfs/project/vso/model
 
 # Add Change-Based Verification tagging for a stress-focused run.
-simmer -t 'sys_tb:*@100' --simulator VCS --vso --vso-cbv --cm line \
+simmer -t 'sys_tb:*@100' --simulator VCS --vso --vso-cbv --vcs-cm line \
   --vso-dbdir /nfs/project/vso/model --vso-phase stress:3
 
 # VSO.ai LCA Coverage Directed Solver, independent of CSO and ICO.
@@ -127,23 +127,25 @@ Run `simmer -h` for all options. MSIE stages must use the same target,
 
 ## VCS compile reuse
 
-The default VCS flow is incremental:
+The default VCS flow automatically reuses unchanged builds:
 
 1. First run builds `<tb>__VCS_VCOMP/simv`.
-2. Later runs reuse the same VCOMP directory.
-3. VCS decides what to rebuild through `-Mupdate`, `-Mdir`, and `-Mlib`.
+2. Later runs compare source content, runfiles, compile arguments, tool identity,
+   environment and required artifacts against the saved fingerprint.
+3. A match bypasses VCS. A miss compiles with Partition Compile by default.
 
-The normal command still enters the VCS compile/elaboration step:
+The normal command performs this automatic hit-or-compile decision:
 
 ```bash
 simmer -t <bench>:<test> --simulator VCS
 ```
 
-That is intentional. It keeps the build correct while allowing VCS incremental
-compile to avoid full rebuilds. Use these only when you intentionally want to
-reuse existing outputs without rebuilding:
+Use `--no-vcs-auto-compile-cache` to always invoke VCS and let Partition Compile
+or `-Mupdate` decide what to rebuild. Use `--no-compile` only when an invalid
+reuse must fail instead of compiling automatically:
 
 ```bash
+simmer -t <bench>:<test> --simulator VCS --no-vcs-auto-compile-cache
 simmer -t <bench>:<test> --simulator VCS --no-compile
 simmer -t <bench>:<test> --simulator VCS --no-compile --no-bazel
 ```
@@ -153,7 +155,8 @@ runfile content, the rendered compile script, compile arguments, external
 compile configuration files and the selected tool environment. It fails before
 simulation when the existing compile output does not match the current inputs.
 
-Use `--recompile` to force a clean VCS compile.
+Use `--recompile` to force a clean VCS compile. It takes precedence over the
+default automatic cache for that invocation.
 
 ### `makelib` and VCS reuse
 
@@ -173,10 +176,9 @@ cells and packages.
 
 ### VCS Partition Compile
 
-VCS X-2025.06-SP2-4 uses regular incremental `-Mupdate` by default. Partition
-Compile is an explicit per-command opt-in through `--vcs-partcomp`. When enabled,
-simmer uses standard autopartitioning, allocation-aware compile parallelism and
-redundant-partition cleanup, passing the detected job allocation as `N`:
+VCS X-2025.06-SP2-4 uses Partition Compile by default. Simmer applies standard
+autopartitioning, allocation-aware compile parallelism and redundant-partition
+cleanup, passing the detected job allocation as `N`:
 
 ```text
 -partcomp
@@ -190,26 +192,24 @@ cluster-wide CPU scan. Simmer checks the current host allocation in
 `LSB_MCPU_HOSTS`/`LSB_HOSTS`, then Slurm per-task allocation and process CPU
 affinity. A multi-host LSF total without per-host evidence falls back to one
 worker. Affinity-only and host-count fallbacks are capped at the conservative
-default of eight. `--vcs-partcomp-jobs N` always overrides automatic detection
-after `--vcs-partcomp` enables the flow.
+default of eight. `--vcs-partcomp-jobs N` always overrides automatic detection.
 
 For an LSF wrapper such as `bs='bsub -I -q syn'`, omitting `-n` normally means
-the queue's default allocation, often one slot. Without `--vcs-partcomp`, both
-commands below use regular `-Mupdate`. Add the flag only when Partition Compile
-is intended, and request parallel capacity from LSF when it is needed:
+the queue's default allocation, often one slot. Request parallel capacity from
+LSF when it is needed:
 
 ```bash
 bs simmer -t 'sys_tb:smoke_test@1' --simulator VCS
-bs -n 8 simmer -t 'sys_tb:smoke_test@1' --simulator VCS --vcs-partcomp
+bs -n 8 simmer -t 'sys_tb:smoke_test@1' --simulator VCS
 ```
 
 The second command selects at most `j8` after LSF grants those slots. It does
 not infer permission from the host's current idle CPU count. A diagnostic `j1`
-run must still opt in explicitly:
+run can set the worker count explicitly:
 
 ```bash
 bs simmer -t 'sys_tb:smoke_test@1' --simulator VCS \
-  --vcs-partcomp --vcs-partcomp-mode auto --vcs-partcomp-jobs 1
+  --vcs-partcomp-mode auto --vcs-partcomp-jobs 1
 ```
 
 The partition database belongs to one VCOMP directory rather than the shared
@@ -229,27 +229,26 @@ with:
 
 ```bash
 simmer -t 'sys_tb:smoke_test@1' --simulator VCS \
-  --vcs-partcomp --vcs-partcomp-jobs 16 --vcs-profile
+  --vcs-partcomp-jobs 16 --vcs-profile
 ```
 
-For repeated invocations that often have no compile-input changes, opt into an
-automatic fingerprint cache:
+Automatic fingerprint reuse is enabled by default. To measure VCS incremental
+behavior even when the fingerprint matches, disable the bypass explicitly:
 
 ```bash
-simmer -t 'sys_tb:smoke_test@1' --simulator VCS --vcs-auto-compile-cache
+simmer -t 'sys_tb:smoke_test@1' --simulator VCS --no-vcs-auto-compile-cache
 ```
 
 A matching fingerprint and existing `simv` bypass VCS compilation. A miss
-compiles normally, unlike strict `--no-compile`. The option cannot be combined
-with `--recompile`.
+compiles normally, unlike strict `--no-compile`.
 
-Available modes after `--vcs-partcomp` are `auto`, `adaptive`, `low`, `high` and
-`relax`. Keep `auto` until profiling shows a reason to tune the
-partition thresholds or adaptive scheduler. Omit `--vcs-partcomp` for the
-normal `-Mupdate` flow:
+Available modes are `auto`, `adaptive`, `low`, `high` and `relax`. Keep `auto`
+until profiling shows a reason to tune the partition thresholds or adaptive
+scheduler. Use `--no-vcs-partcomp` for the regular `-Mupdate` flow. This opt-out
+is also required for the known Y-2026.03 partition frontend regression:
 
 ```bash
-simmer -t 'sys_tb:smoke_test@1' --simulator VCS --vcs-profile
+simmer -t 'sys_tb:smoke_test@1' --simulator VCS --no-vcs-partcomp --vcs-profile
 ```
 
 To create a versioned baseline database for multiple workspaces, use a path
@@ -407,8 +406,11 @@ Enable debug features explicitly:
 simmer -t <bench>:<test> --simulator VCS --waves
 simmer -t <bench>:<test> --simulator VCS --gui
 simmer -t <bench>:<test> --simulator VCS --smartlog
-simmer -t <bench>:<test> --simulator VCS --xprop F
+simmer -t <bench>:<test> --simulator VCS --vcs-xprop F
 ```
+
+`--xprop` remains a compatibility spelling for VCS. Use `--vcs-xprop` in new
+VCS commands so simulator-specific controls stay grouped in `simmer -h`.
 
 VCS wave dumping supports FSDB only.
 
@@ -552,8 +554,9 @@ For quiet normal runs, avoid `--tool-debug`; it prints scheduler polling noise.
   number of concurrent tests to account for those threads.
 - Avoid waves, `-debug_access`, VPI and SmartLog in throughput regressions.
 
-DTL (`--vcs-partcomp --dtl`) and VCS ICO (`--ico`) are opt-in advanced flows. ICO does not change VCS compilation. Simmer initializes a
-shared CDB with `crg -dir <shared_record> -shared init` and passes the recommended
+DTL (`--dtl`) and VCS ICO (`--ico`) are opt-in advanced flows. DTL requires the
+default Partition Compile flow. ICO does not change VCS compilation. Simmer
+initializes a shared CDB with `crg -dir <shared_record> -shared init` and passes the recommended
 `+ntb_solver_bias_mode_auto_config=2`, shared-record, work-directory, UVM test-type
 and test-name options to each `simv`. Existing initialized CDBs are reused.
 
@@ -577,10 +580,11 @@ licenses, setup and real workload validation.
 
 ## Coverage generation and merge
 
-VCS `--cm` writes one `.vdb` per vcomp and generates
+VCS `--vcs-cm` writes one `.vdb` per vcomp and generates
 `<vcomp>_vcs_cov_merge.sh`. The same configured VCS runner is used for `urg`
 and Verdi. Xcelium `--coverage` keeps IMC generation and merge in the Xcelium
 adapter. Coverage switches from one backend are rejected by the other.
+The historical VCS spelling `--cm` remains a compatibility alias.
 
 VCS coverage tuning follows the Y-2026.03 Command Reference and Coverage Guide.
 Use `--vcs-cm-cond obs+event` for observability-based condition coverage plus

--- a/lib/simulators/vcs.py
+++ b/lib/simulators/vcs.py
@@ -386,7 +386,7 @@ class VcsSimulator(SimulatorInterface):
     def get_partition_compile_options(self, vcomp_job):
         effective_mode = self.get_effective_partcomp_mode()
         if effective_mode == 'disabled':
-            log.info("VCS Partition Compile is disabled by default; using -Mupdate")
+            log.info("VCS Partition Compile is disabled; using -Mupdate")
             return ''
 
         if self.options.dtl:

--- a/lib/simulators/vcs_options.py
+++ b/lib/simulators/vcs_options.py
@@ -11,10 +11,11 @@ def validate_vcs_runtime_options(options, parser):
             options.vcs_urg_parallel,
             options.vcs_urg_show_tests,
     ]) and not options.cm:
-        parser.error("VCS coverage detail switches require '--cm'. "
+        parser.error("VCS coverage detail switches require '--vcs-cm'. "
                      "Stopping before Bazel starts.")
     if options.vcs_cm_line is not None and 'line' not in options.cm and 'A' not in options.cm:
-        parser.error("--vcs-cm-line requires line coverage in '--cm' (for example '--cm line' or '--cm A'). "
+        parser.error("--vcs-cm-line requires line coverage in '--vcs-cm' "
+                     "(for example '--vcs-cm line' or '--vcs-cm A'). "
                      "Stopping before Bazel starts.")
     if options.vcs_cm_report is not None:
         if 'svpackages' in options.vcs_cm_report and 'line' not in options.cm and 'A' not in options.cm:
@@ -48,8 +49,8 @@ def validate_vcs_runtime_options(options, parser):
             options.vcs_xprop_banner,
             options.vcs_xprop_report,
     ]):
-        parser.error("VCS xprop helper switches require XPROP to be enabled. "
-                     "Do not combine them with '--xprop D'. Stopping before Bazel starts.")
+        parser.error("VCS xprop helper switches require '--vcs-xprop F' or '--vcs-xprop C'. "
+                     "Do not combine them with '--vcs-xprop D'. Stopping before Bazel starts.")
     if options.fgp is not None and options.fgp < 1:
         parser.error("--fgp must be a positive integer thread count. Stopping before Bazel starts.")
     if options.vcs_runner is not None and not options.vcs_runner.strip():
@@ -67,7 +68,7 @@ def validate_vcs_runtime_options(options, parser):
         '--vcs-partcomp-sharedlib',
     }.intersection(options.vcs_explicit_switches)
     if not options.vcs_partcomp and partcomp_detail_switches:
-        parser.error("VCS Partition Compile details require '--vcs-partcomp'. "
+        parser.error("VCS Partition Compile details cannot be combined with '--no-vcs-partcomp'. "
                      "Stopping before Bazel starts.")
     if options.vcs_partcomp_sharedlib is not None:
         sharedlib = os.path.abspath(options.vcs_partcomp_sharedlib)
@@ -77,14 +78,8 @@ def validate_vcs_runtime_options(options, parser):
         if options.vcs_partcomp_dir is not None and sharedlib == os.path.abspath(options.vcs_partcomp_dir):
             parser.error("--vcs-partcomp-dir and --vcs-partcomp-sharedlib must use different directories. "
                          "Stopping before Bazel starts.")
-    if options.vcs_auto_compile_cache and options.no_compile:
-        parser.error("--vcs-auto-compile-cache cannot be combined with --no-compile. "
-                     "Stopping before Bazel starts.")
-    if options.vcs_auto_compile_cache and options.recompile:
-        parser.error("--vcs-auto-compile-cache cannot be combined with --recompile. "
-                     "Stopping before Bazel starts.")
     if options.dtl and not options.vcs_partcomp:
-        parser.error("--dtl requires '--vcs-partcomp'. Stopping before Bazel starts.")
+        parser.error("--dtl cannot be combined with '--no-vcs-partcomp'. Stopping before Bazel starts.")
     if options.dtl and any([
             options.vcs_partcomp_mode != 'auto',
             options.vcs_partcomp_dir is not None,
@@ -131,16 +126,16 @@ def validate_vcs_runtime_options(options, parser):
             parser.error("--vso-target-metric accepts comma-separated all, assert, cond, fsm, group, line, or tgl. "
                          "Stopping before Bazel starts.")
     if options.vso and options.vso_target_metric is None and not options.cm:
-        parser.error("VSO.ai init requires --cm or --vso-target-metric. Stopping before Bazel starts.")
+        parser.error("VSO.ai init requires --vcs-cm or --vso-target-metric. Stopping before Bazel starts.")
     if options.vso and options.vso_target_metric is None and options.cm == 'branch':
-        parser.error("VSO.ai cannot derive a supported target metric from --cm branch; pass --vso-target-metric. "
+        parser.error("VSO.ai cannot derive a supported target metric from --vcs-cm branch; pass --vso-target-metric. "
                      "Stopping before Bazel starts.")
     if options.vso_cbv:
         line_enabled = options.cm and ('line' in options.cm or 'A' in options.cm)
         port_toggle_enabled = (options.cm and ('tgl' in options.cm or 'A' in options.cm)
                                and options.vcs_cm_tgl == 'portsonly')
         if not line_enabled and not port_toggle_enabled:
-            parser.error("--vso-cbv requires --cm line or --cm tgl --vcs-cm-tgl portsonly for the Day0 model. "
+            parser.error("--vso-cbv requires --vcs-cm line or --vcs-cm tgl --vcs-cm-tgl portsonly for the Day0 model. "
                          "Stopping before Bazel starts.")
     if any([options.vso_ccex_rca, options.vso_ccex_auto_merge_dir is not None]) and not options.vso_ccex:
         parser.error("VSO.ai CCEX detail switches require '--vso-ccex'. Stopping before Bazel starts.")

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -68,11 +68,24 @@ class VcsRuntimeContractTest(unittest.TestCase):
         normalized_help = " ".join(help_text.split())
         self.assertIn("Bazel 7.7.1, Python 3.12", normalized_help)
         self.assertIn("Quote all test globs", normalized_help)
-        self.assertIn("default: disabled", normalized_help)
+        self.assertIn("enabled (default)", normalized_help)
+        self.assertIn("--no-vcs-partcomp", normalized_help)
+        self.assertIn("--no-vcs-auto-compile-cache", normalized_help)
+        self.assertIn("--vcs-cm", normalized_help)
+        self.assertIn("--vcs-xprop", normalized_help)
+        self.assertNotIn("--lmstat", normalized_help)
         self.assertIn("must already exist", normalized_help)
         self.assertIn("custom external partcomp/sharedlib directories are preserved", normalized_help)
         self.assertIn("Run this before --msie-prim", normalized_help)
         self.assertIn("Requires EMU_JINJA2_PATH", normalized_help)
+        self.assertIn("\n    --wave-type", help_text)
+        self.assertIn("\n    --mce-build-count", help_text)
+        self.assertIn("\n    --vcs-cm-line", help_text)
+        self.assertIn("\n    --vcs-partcomp-mode", help_text)
+        self.assertIn("\n    --vcs-xprop-flowctrl", help_text)
+        self.assertIn("\n    --ico-workdir", help_text)
+        self.assertIn("\n    --vso-workdir", help_text)
+        self.assertIn("\n    --vso-ccex-rca", help_text)
 
     def test_zero_test_timeout_disables_job_timeout(self):
         self.assertEqual(0, resolve_test_timeout_hours({"timeout_minutes": 0}, 12.0, False))
@@ -136,7 +149,7 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertIn("fox_xprop.txt", msie_simulator.generate_compile_options(msie_vcomp)["xprop_cmd"])
 
     def test_explicit_vcs_xprop_f_enables_compile_option(self):
-        options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--xprop", "F"])
+        options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--vcs-xprop", "F"])
         simulator = VcsSimulator(options, DummyRegressionConfig(), None)
         simulator._vcs_tool_identity = "VCS Y-2026.03 unit test"
         vcomp = DummyVcompJob()
@@ -147,10 +160,25 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertIn(str(xprop_config), simulator.get_compile_fingerprint_inputs(vcomp)["extra_input_paths"])
 
     def test_explicit_xprop_disable_still_maps_to_none(self):
-        vcs_options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--xprop", "D"])
+        vcs_options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--vcs-xprop", "D"])
 
         self.assertIsNone(vcs_options.xprop)
         self.assertTrue(vcs_options.xprop_was_explicit)
+
+    def test_vcs_primary_switches_keep_compatibility_aliases(self):
+        primary = parse_args(["--simulator", "VCS", "--vcs-cm", "line+tgl", "--vcs-xprop", "C"])
+        compatible = parse_args(["--simulator", "VCS", "--cm", "line+tgl", "--xprop", "C"])
+
+        self.assertEqual(primary.cm, compatible.cm)
+        self.assertEqual(primary.xprop, compatible.xprop)
+        self.assertTrue(primary.xprop_was_explicit)
+        self.assertIn("--vcs-cm", primary.vcs_explicit_switches)
+        self.assertIn("--vcs-xprop", primary.vcs_explicit_switches)
+
+        with self.assertRaisesRegex(ValueError, "VCS-only"):
+            self._validated(["--simulator", "XRUN", "--vcs-xprop", "F"])
+        with self.assertRaisesRegex(ValueError, "VCS-only"):
+            self._validated(["--simulator", "XRUN", "--vcs-cm", "line"])
 
     def test_jobs_option_requires_a_positive_integer(self):
         self.assertEqual(3, parse_args(["--jobs", "3"]).jobs)
@@ -259,7 +287,7 @@ class VcsRuntimeContractTest(unittest.TestCase):
             "--simulator",
             "VCS",
             "--vso",
-            "--cm",
+            "--vcs-cm",
             "line",
         ])
         self.assertEqual("", normal.get_compile_template_context(DummyVcompJob())["vso_workdir"])
@@ -452,13 +480,29 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertTrue(VcsSimulator(smartlog_options, DummyRegressionConfig(), None).use_smartlog())
         self.assertTrue(VcsSimulator(waves_options, DummyRegressionConfig(), None).use_smartlog())
 
-    def test_vcs_partition_compile_is_disabled_by_default(self):
+    def test_vcs_partition_compile_and_cache_are_enabled_by_default(self):
         options = parse_args(["-t", "unit:test", "--simulator", "VCS"])
         simulator = VcsSimulator(options, DummyRegressionConfig(), None)
 
-        self.assertFalse(options.vcs_partcomp)
-        self.assertEqual("", simulator.generate_compile_options(DummyVcompJob())["partcomp_opts"])
-        self.assertEqual("disabled", simulator.get_effective_partcomp_mode())
+        self.assertTrue(options.vcs_partcomp)
+        self.assertTrue(options.vcs_auto_compile_cache)
+        self.assertEqual("auto", simulator.get_effective_partcomp_mode())
+        self.assertTrue(simulator.should_auto_reuse_compile())
+
+        disabled_options = parse_args([
+            "-t",
+            "unit:test",
+            "--simulator",
+            "VCS",
+            "--no-vcs-partcomp",
+            "--no-vcs-auto-compile-cache",
+        ])
+        disabled_simulator = VcsSimulator(disabled_options, DummyRegressionConfig(), None)
+        self.assertFalse(disabled_options.vcs_partcomp)
+        self.assertFalse(disabled_options.vcs_auto_compile_cache)
+        self.assertEqual("", disabled_simulator.generate_compile_options(DummyVcompJob())["partcomp_opts"])
+        self.assertEqual("disabled", disabled_simulator.get_effective_partcomp_mode())
+        self.assertFalse(disabled_simulator.should_auto_reuse_compile())
 
     def test_vcs_partition_compile_opt_in_uses_vcomp_owned_database(self):
         options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--vcs-partcomp"])
@@ -571,9 +615,9 @@ class VcsRuntimeContractTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self._validated(["--simulator", "VCS", "--vcs-partcomp-jobs", "0"])
         with self.assertRaises(ValueError):
-            self._validated(["--simulator", "VCS", "--vcs-partcomp-jobs", "4"])
+            self._validated(["--simulator", "VCS", "--no-vcs-partcomp", "--vcs-partcomp-jobs", "4"])
         with self.assertRaises(ValueError):
-            self._validated(["--simulator", "VCS", "--vcs-partcomp-mode", "adaptive"])
+            self._validated(["--simulator", "VCS", "--no-vcs-partcomp", "--vcs-partcomp-mode", "adaptive"])
         with self.assertRaises(SystemExit):
             parse_args(["--simulator", "VCS", "--vcs-partcomp-mode", "disabled"])
         sharedlib = tempfile.mkdtemp()
@@ -588,8 +632,10 @@ class VcsRuntimeContractTest(unittest.TestCase):
                 sharedlib,
             ])
 
-        with self.assertRaises(ValueError):
-            self._validated(["--simulator", "VCS", "--vcs-auto-compile-cache", "--recompile"])
+        for flow_control in ("--recompile", "--no-compile"):
+            with self.subTest(flow_control=flow_control):
+                options, _ = self._validated(["--simulator", "VCS", flow_control])
+                self.assertTrue(options.vcs_auto_compile_cache)
 
     def test_vcs_partcomp_auto_jobs_use_scheduler_allocation(self):
         with mock.patch("lib.simulators.vcs.os.sched_getaffinity", create=True, return_value=set(range(64))):
@@ -626,7 +672,7 @@ class VcsRuntimeContractTest(unittest.TestCase):
             self.assertEqual("VCS Y-2026.03", probe.get_tool_identity())
         self.assertEqual(["vcs", "-full64", "-ID"], run.call_args.args[0][-3:])
 
-    def test_vcs_partcomp_default_is_disabled_for_single_slot_lsf_job(self):
+    def test_vcs_partcomp_default_preserves_single_slot_lsf_job(self):
         lsf_environment = {
             "LSB_DJOB_NUMPROC": "1",
             "LSB_HOSTS": "sh-cloud30",
@@ -642,15 +688,10 @@ class VcsRuntimeContractTest(unittest.TestCase):
             partcomp_opts = simulator.generate_compile_options(DummyVcompJob())["partcomp_opts"]
             metrics = simulator.collect_compile_metrics(SimpleNamespace(log_path="missing", compile_cache_hit=False))
 
-        self.assertEqual("", partcomp_opts)
-        self.assertEqual("disabled", metrics["partcomp_mode"])
-        self.assertIsNone(metrics["partcomp_jobs"])
-
-        cache_options = parse_args(["--simulator", "VCS", "--vcs-auto-compile-cache"])
-        cache_simulator = VcsSimulator(cache_options, DummyRegressionConfig(), None)
-        with mock.patch.dict(os.environ, lsf_environment, clear=True), \
-             mock.patch("lib.simulators.vcs.os.sched_getaffinity", create=True, return_value=set(range(64))):
-            self.assertEqual("", cache_simulator.generate_compile_options(DummyVcompJob())["partcomp_opts"])
+        self.assertIn("-partcomp", shlex.split(partcomp_opts))
+        self.assertIn("-fastpartcomp=j1", shlex.split(partcomp_opts))
+        self.assertEqual("auto", metrics["partcomp_mode"])
+        self.assertEqual(1, metrics["partcomp_jobs"])
 
     def test_vcs_explicit_partcomp_jobs_preserve_single_worker_flow(self):
         options = parse_args(["--simulator", "VCS", "--vcs-partcomp", "--vcs-partcomp-jobs", "1"])
@@ -684,19 +725,32 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertIn("-fastpartcomp=j1", partcomp_args)
 
     def test_vcs_dtl_uses_required_partition_compile_flow(self):
-        disabled_options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--dtl"])
+        disabled_options = parse_args([
+            "-t",
+            "unit:test",
+            "--simulator",
+            "VCS",
+            "--no-vcs-partcomp",
+            "--dtl",
+        ])
         disabled_simulator = VcsSimulator(disabled_options, DummyRegressionConfig(), None)
         self.assertEqual("", disabled_simulator.generate_compile_options(DummyVcompJob())["partcomp_opts"])
 
         with self.assertRaises(ValueError):
-            self._validated(["-t", "unit:test", "--simulator", "VCS", "--dtl"])
+            self._validated([
+                "-t",
+                "unit:test",
+                "--simulator",
+                "VCS",
+                "--no-vcs-partcomp",
+                "--dtl",
+            ])
 
         options, simulator = self._validated([
             "-t",
             "unit:test",
             "--simulator",
             "VCS",
-            "--vcs-partcomp",
             "--dtl",
         ])
         vcomp = DummyVcompJob()
@@ -801,6 +855,10 @@ class VcsRuntimeContractTest(unittest.TestCase):
             self._validated(["-t", "unit:test", "--simulator", "XRUN", "--smartlog"])
         with self.assertRaises(ValueError):
             self._validated(["-t", "unit:test", "--simulator", "XRUN", "--vcs-partcomp"])
+        with self.assertRaises(ValueError):
+            self._validated(["-t", "unit:test", "--simulator", "XRUN", "--no-vcs-partcomp"])
+        with self.assertRaises(ValueError):
+            self._validated(["-t", "unit:test", "--simulator", "XRUN", "--no-vcs-auto-compile-cache"])
         with self.assertRaises(ValueError):
             self._validated(["-t", "unit:test", "--simulator", "XRUN", "--vcs-partcomp-jobs", "4"])
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- enable VCS Partition Compile and automatic compile fingerprint reuse by default, with explicit opt-outs
- add primary `--vcs-cm` and `--vcs-xprop` spellings while preserving `--cm` and `--xprop` compatibility
- indent master/child options in `simmer -h` and remove the race-prone `--lmstat` hook
- update VCS workflow documentation and runtime contract coverage

## Validation
- 8 compile cache tests passed
- 3 documentation tests passed
- focused VCS parser/default/backend tests passed
- full runtime contract: 66 passed; 6 unchanged Windows-only baseline failures (path separators, bash path handling, temporary XML permissions)
- YAPF and `git diff --check` passed