### PR TITLE
Require exact simmer option spelling

### DIFF
--- a/bin/args_parse/parser.py
+++ b/bin/args_parse/parser.py
@@ -97,6 +97,7 @@ def create_parser():
          "  simmer -t 'gate_tb:test@1' --simulator XRUN --msie-prim dut --msie-primary-name dut_wc --msie-primary-key KEY\n"
          "  simmer -t 'gate_tb:test@1' --simulator XRUN --msie-incr dut_wc --msie-primary-key KEY"),
         formatter_class=SimmerHelpFormatter,
+        allow_abbrev=False,
     )
 
     add_debug_arguments(parser)

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -92,6 +92,12 @@ class VcsRuntimeContractTest(unittest.TestCase):
     def test_zero_test_timeout_disables_job_timeout(self):
         self.assertEqual(0, resolve_test_timeout_hours({"timeout_minutes": 0}, 12.0, False))
 
+    def test_long_options_require_exact_spelling(self):
+        self.assertTrue(parse_args(["--recompile"]).recompile)
+        self.assertEqual(10, parse_args(["--his"]).history)
+        with self.assertRaises(SystemExit):
+            parse_args(["--recom"])
+
     def test_simulation_directory_name_separates_iteration_and_optional_suffix(self):
         common_arguments = ("unit_tb", "VCS", "smoke", 42, 1)
 


### PR DESCRIPTION
## Summary

- disable argparse long-option prefix abbreviation for simmer
- preserve explicitly declared aliases such as `--his` and `--cm`
- reject accidental spellings such as `--recom` instead of treating them as `--recompile`

## Root cause

Python argparse accepts unique long-option prefixes by default. This made incomplete option names silently behave like valid commands.

## Validation

- focused exact-option contract test passed
- WSL Python 3.12 VCS runtime contract: 82/82 passed
- YAPF 0.43 and `git diff --check` passed

Follow-up to #12.
