### PR TITLE
Stabilize and coordinate VCS compile cache reuse

### DIFF
--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -315,9 +315,13 @@ class VCompJob(Job):
         compile_script = compile_template.render(**template_context)
         sim_artifacts.write_executable_script(vcomp_sh_path, compile_script)
         fingerprint_inputs = self.simulator.get_compile_fingerprint_inputs(self)
+        fingerprint_script = compile_cache.normalize_compile_script_paths(
+            self.simulator.compile_script_for_fingerprint(compile_script),
+            {"BAZEL_RUNFILES_MAIN": self.bazel_runfiles_main},
+        )
         self.compile_fingerprint = compile_cache.compile_fingerprint(
             self.rcfg.proj_dir,
-            self.simulator.compile_script_for_fingerprint(compile_script),
+            fingerprint_script,
             self.bazel_compile_args,
             os.path.join(self.bazel_runfiles_main, self.tb_options["compile_inputs"])
             if self.tb_options["compile_inputs"] else None,

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -229,8 +229,28 @@ class VCompJob(Job):
         self.main_cmdline = None
         self.cov_work_dir = None
         self.compile_cache_hit = False
+        self._compile_lock = None
+
+    def _acquire_compile_lock(self):
+        # Keep the lock outside the mutable compile directory so recompile cleanup cannot replace it.
+        lock_path = self.job_dir + ".compile.lock"
+        self._compile_lock = compile_cache.CompileDirectoryLock(lock_path)
+        if not self._compile_lock.acquire(blocking=False):
+            log.info("Waiting for compile directory lock %s", lock_path)
+            self._compile_lock.acquire()
+        log.debug("Acquired compile directory lock %s", lock_path)
+
+    def _release_compile_lock(self):
+        compile_lock = getattr(self, "_compile_lock", None)
+        if compile_lock is None:
+            return
+        lock_path = compile_lock.path
+        compile_lock.release()
+        self._compile_lock = None
+        log.debug("Released compile directory lock %s", lock_path)
 
     def pre_run(self):
+        self._acquire_compile_lock()
         super(VCompJob, self).pre_run()
 
         options = self.rcfg.options
@@ -481,19 +501,26 @@ class VCompJob(Job):
         # log_level is determined by initial return code and potential warning failures
         log_level("%s vcomp %s in %s", self.name, self.jobstatus, self.job_dir)
         simmer_results.record_compile_job(getattr(self.rcfg, "simmer_results_run", None), self)
+        self._release_compile_lock()
 
         # Base class post_run might handle completion, but setting explicitly ensures it
         # Note: '_completed' isn't standard, jobstatus.completed is the way to check
         # self._completed = True # This line might be unnecessary if super() handles it
 
     def launch_failed(self, exc):
-        super().launch_failed(exc)
-        self.error_message = str(exc)
-        simmer_results.record_compile_job(getattr(self.rcfg, "simmer_results_run", None), self)
+        try:
+            super().launch_failed(exc)
+            self.error_message = str(exc)
+            simmer_results.record_compile_job(getattr(self.rcfg, "simmer_results_run", None), self)
+        finally:
+            self._release_compile_lock()
 
     def post_run_failed(self, exc):
-        super().post_run_failed(exc)
-        simmer_results.record_compile_job(getattr(self.rcfg, "simmer_results_run", None), self)
+        try:
+            super().post_run_failed(exc)
+            simmer_results.record_compile_job(getattr(self.rcfg, "simmer_results_run", None), self)
+        finally:
+            self._release_compile_lock()
 
     def __repr__(self):
         sim_name = self.simulator.get_name() if hasattr(self, 'simulator') else '???'

--- a/bin/templates/sim_template.sh.j2
+++ b/bin/templates/sim_template.sh.j2
@@ -132,6 +132,12 @@ function run_test {
     fi
     {% endfor %}
 
+    if [ "$overall_exit_code" -ne 0 ]; then
+        echo "%E- ERROR: Simulation preparation failed; skipping main simulation."
+        OVERALL_EXIT_CODE=$overall_exit_code
+        return
+    fi
+
     # The timeout monitor starts here, after sidecar and pre-run setup complete.
     : > "$TEST_LOG_PATH"
     local SIMULATION_START_SECONDS=$SECONDS

--- a/lib/compile_cache.py
+++ b/lib/compile_cache.py
@@ -8,6 +8,48 @@ import tempfile
 FINGERPRINT_FILE = ".compile_fingerprint.json"
 
 
+class CompileDirectoryLock:
+    """Advisory lock held while validating or updating a compile directory."""
+
+    def __init__(self, path):
+        self.path = os.path.abspath(os.fspath(path))
+        self._filep = None
+
+    def acquire(self, blocking=True):
+        if self._filep is not None:
+            return True
+
+        import fcntl
+
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        filep = open(self.path, "a+", encoding="utf-8")
+        operation = fcntl.LOCK_EX
+        if not blocking:
+            operation |= fcntl.LOCK_NB
+        try:
+            fcntl.flock(filep, operation)
+        except BlockingIOError:
+            filep.close()
+            return False
+        except BaseException:
+            filep.close()
+            raise
+        self._filep = filep
+        return True
+
+    def release(self):
+        if self._filep is None:
+            return
+
+        import fcntl
+
+        try:
+            fcntl.flock(self._filep, fcntl.LOCK_UN)
+        finally:
+            self._filep.close()
+            self._filep = None
+
+
 def _digest_bytes(*values):
     digest = hashlib.sha256()
     for value in values:
@@ -91,7 +133,7 @@ def compile_fingerprint(project_dir,
                         environment=None):
     """Return the source, generated filelist and compile-mode identity."""
     fingerprint = {
-        "schema_version": 5,
+        "schema_version": 6,
         "compile_script_sha256": _digest_bytes(compile_script.encode("utf-8")),
         "compile_args_sha256": _digest_bytes(_file_bytes(compile_args_path)),
         "environment": dict(sorted((environment or {}).items())),

--- a/lib/compile_cache.py
+++ b/lib/compile_cache.py
@@ -72,6 +72,16 @@ def _extra_inputs_content_digest(paths):
     return _digest_bytes(*(digest.encode("ascii") for digest in file_digests))
 
 
+def normalize_compile_script_paths(compile_script, path_replacements):
+    """Replace host-specific absolute paths with stable fingerprint tokens."""
+    normalized = compile_script
+    replacements = ((os.path.abspath(os.fspath(path)), "<{}>".format(name)) for name, path in path_replacements.items()
+                    if path)
+    for path, token in sorted(replacements, key=lambda item: len(item[0]), reverse=True):
+        normalized = normalized.replace(path, token)
+    return normalized
+
+
 def compile_fingerprint(project_dir,
                         compile_script,
                         compile_args_path,
@@ -119,6 +129,19 @@ def invalidate_compile_fingerprint(job_dir):
         pass
 
 
+def _changed_fingerprint_fields(actual, expected, prefix=""):
+    changed = []
+    for key in sorted(set(actual) | set(expected)):
+        field = "{}.{}".format(prefix, key) if prefix else key
+        actual_value = actual.get(key)
+        expected_value = expected.get(key)
+        if isinstance(actual_value, dict) and isinstance(expected_value, dict):
+            changed.extend(_changed_fingerprint_fields(actual_value, expected_value, field))
+        elif actual_value != expected_value:
+            changed.append(field)
+    return changed
+
+
 def validate_compile_fingerprint(job_dir, expected):
     path = _fingerprint_path(job_dir)
     if not os.path.isfile(path):
@@ -126,7 +149,9 @@ def validate_compile_fingerprint(job_dir, expected):
     with open(path, "r", encoding="utf-8") as filep:
         actual = json.load(filep)
     if actual != expected:
-        raise RuntimeError("--no-compile build fingerprint mismatch in {}. Recompile this testbench.".format(job_dir))
+        changed = ", ".join(_changed_fingerprint_fields(actual, expected))
+        raise RuntimeError("Compile build fingerprint mismatch in {} (changed: {}). Recompile this testbench.".format(
+            job_dir, changed))
 
 
 def can_reuse_compile(job_dir, expected, validate_artifacts):

--- a/lib/simulators/vcs.py
+++ b/lib/simulators/vcs.py
@@ -175,11 +175,12 @@ class VcsSimulator(SimulatorInterface):
             raise RuntimeError(
                 "Unable to resolve the VCS build ID with '{}'. Set RV_VCS_TOOL_ID to the site VCS release ID: {}".
                 format(shlex.join(command), exc)) from exc
-        identity = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part.strip())
+        identity = result.stdout.strip()
         if result.returncode != 0 or not identity:
+            diagnostic = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part.strip())
             raise RuntimeError(
                 "Unable to resolve the VCS build ID with '{}'. Set RV_VCS_TOOL_ID to the site VCS release ID.\n{}".
-                format(shlex.join(command), identity))
+                format(shlex.join(command), diagnostic))
         self._vcs_tool_identity = identity
         return self._vcs_tool_identity
 
@@ -263,9 +264,7 @@ class VcsSimulator(SimulatorInterface):
         xprop_config = getattr(vcomp_job, "vcs_xprop_config_path", None)
         if xprop_config:
             inputs["extra_input_paths"].append(xprop_config)
-        inputs["environment"].update(
-            {key: os.environ.get(key, "")
-             for key in ("LM_LICENSE_FILE", "VCS_HOME", "VSO_HOME")})
+        inputs["environment"].update({key: os.environ.get(key, "") for key in ("VCS_HOME", "VSO_HOME")})
         inputs["environment"]["VCS_TOOL_ID"] = self.get_tool_identity()
         return inputs
 

--- a/tests/compile_cache_test.py
+++ b/tests/compile_cache_test.py
@@ -4,7 +4,7 @@ import unittest
 from pathlib import Path
 
 from lib.compile_cache import (can_reuse_compile, compile_fingerprint, invalidate_compile_fingerprint,
-                               validate_compile_fingerprint, write_compile_fingerprint)
+                               normalize_compile_script_paths, validate_compile_fingerprint, write_compile_fingerprint)
 
 
 class CompileCacheTest(unittest.TestCase):
@@ -67,6 +67,43 @@ class CompileCacheTest(unittest.TestCase):
         validate_compile_fingerprint(job_dir, fingerprint)
         with self.assertRaises(RuntimeError):
             validate_compile_fingerprint(job_dir, dict(fingerprint, compile_script="changed"))
+
+    def test_fingerprint_normalizes_host_specific_runfiles_root(self):
+        project, _, compile_args = self._project()
+        first_root = project / "host-a" / "bazel-bin" / "tb.runfiles" / "__main__"
+        second_root = project / "host-b" / "bazel-bin" / "tb.runfiles" / "__main__"
+        first_script = "cd {}\nvcs -file {}/tb_compile_args.f\n".format(first_root, first_root)
+        second_script = "cd {}\nvcs -file {}/tb_compile_args.f\n".format(second_root, second_root)
+
+        first = normalize_compile_script_paths(first_script, {"BAZEL_RUNFILES_MAIN": first_root})
+        second = normalize_compile_script_paths(second_script, {"BAZEL_RUNFILES_MAIN": second_root})
+
+        self.assertEqual(first, second)
+        self.assertEqual(
+            compile_fingerprint(project, first, compile_args),
+            compile_fingerprint(project, second, compile_args),
+        )
+
+    def test_fingerprint_mismatch_reports_changed_fields(self):
+        project, _, compile_args = self._project()
+        job_dir = project / "vcomp"
+        job_dir.mkdir()
+        fingerprint = compile_fingerprint(
+            project,
+            "vcs -f compile.f",
+            compile_args,
+            environment={"PATH": "/tools/vcs/bin"},
+        )
+        write_compile_fingerprint(job_dir, fingerprint)
+        changed = compile_fingerprint(
+            project,
+            "vcs -debug_access -f compile.f",
+            compile_args,
+            environment={"PATH": "/different/tools/vcs/bin"},
+        )
+
+        with self.assertRaisesRegex(RuntimeError, r"compile_script_sha256, environment\.PATH"):
+            validate_compile_fingerprint(job_dir, changed)
 
     def test_automatic_reuse_turns_validation_failure_into_cache_miss(self):
         project, _, compile_args = self._project()

--- a/tests/compile_cache_test.py
+++ b/tests/compile_cache_test.py
@@ -1,10 +1,13 @@
+import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from lib.compile_cache import (can_reuse_compile, compile_fingerprint, invalidate_compile_fingerprint,
-                               normalize_compile_script_paths, validate_compile_fingerprint, write_compile_fingerprint)
+from lib.compile_cache import (CompileDirectoryLock, can_reuse_compile, compile_fingerprint,
+                               invalidate_compile_fingerprint, normalize_compile_script_paths,
+                               validate_compile_fingerprint, write_compile_fingerprint)
 
 
 class CompileCacheTest(unittest.TestCase):
@@ -35,6 +38,22 @@ class CompileCacheTest(unittest.TestCase):
         self.assertNotEqual(initial, source_changed)
         self.assertEqual(initial["compile_inputs_manifest_sha256"], source_changed["compile_inputs_manifest_sha256"])
         self.assertNotEqual(source_changed, mode_changed)
+
+    @unittest.skipUnless(os.name == "posix", "fcntl locks require POSIX")
+    def test_compile_directory_lock_serializes_independent_processes(self):
+        lock_path = Path(tempfile.mkdtemp()) / "vcomp.compile.lock"
+        first = CompileDirectoryLock(lock_path)
+        probe = ("import fcntl, sys\n"
+                 "with open(sys.argv[1], 'a+', encoding='utf-8') as filep:\n"
+                 "    try:\n"
+                 "        fcntl.flock(filep, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+                 "    except BlockingIOError:\n"
+                 "        sys.exit(1)\n")
+
+        self.assertTrue(first.acquire(blocking=False))
+        self.assertEqual(1, subprocess.run([sys.executable, "-c", probe, str(lock_path)], check=False).returncode)
+        first.release()
+        self.assertEqual(0, subprocess.run([sys.executable, "-c", probe, str(lock_path)], check=False).returncode)
 
     def test_fingerprint_ignores_unrelated_tracked_changes(self):
         project, _, compile_args = self._project()

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -148,7 +148,9 @@ class VcsRuntimeContractTest(unittest.TestCase):
                                   job_dir,
                                   simulation_command,
                                   socket_sidecars=(),
-                                  sim_working_dir=None):
+                                  sim_working_dir=None,
+                                  pre_run_cmd="",
+                                  pre_sim_commands=()):
         jinja_environment = jinja2.Environment(undefined=jinja2.StrictUndefined)
         jinja_environment.filters["shell_quote"] = shlex.quote
         simulation_template = jinja_environment.from_string(self._read_repo_file("bin/templates/sim_template.sh.j2"))
@@ -168,8 +170,8 @@ class VcsRuntimeContractTest(unittest.TestCase):
             log_check_args="",
             options=SimpleNamespace(skip_parse_sim_log=1),
             post_sim_commands=[],
-            pre_run_cmd="",
-            pre_sim_commands=[],
+            pre_run_cmd=pre_run_cmd,
+            pre_sim_commands=pre_sim_commands,
             sim_working_dir=str(sim_working_dir or Path(job_dir) / "sim work"),
             simulation_command=simulation_command,
             sockets=socket_sidecars,
@@ -477,6 +479,7 @@ class VcsRuntimeContractTest(unittest.TestCase):
             vcs_simulator._vcs_tool_identity = "VCS Y-2026.03 unit test"
             vcs_inputs = vcs_simulator.get_compile_fingerprint_inputs(DummyVcompJob())
             self.assertIn(vcs_hier.name, vcs_inputs["extra_input_paths"])
+            self.assertNotIn("LM_LICENSE_FILE", vcs_inputs["environment"])
 
             xrun_options = parse_args([
                 "--simulator",
@@ -759,7 +762,9 @@ class VcsRuntimeContractTest(unittest.TestCase):
 
         probe = VcsSimulator(options, DummyRegressionConfig(), None)
         with mock.patch("lib.simulators.vcs.subprocess.run",
-                        return_value=SimpleNamespace(returncode=0, stdout="VCS Y-2026.03\n", stderr="")) as run:
+                        return_value=SimpleNamespace(returncode=0,
+                                                     stdout="VCS Y-2026.03\n",
+                                                     stderr="transient license warning\n")) as run:
             self.assertEqual("VCS Y-2026.03", probe.get_tool_identity())
         self.assertEqual(["vcs", "-full64", "-ID"], run.call_args.args[0][-3:])
 
@@ -1318,6 +1323,33 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertFalse((job_dir / "simulation_duration_s").exists())
         self.assertFalse((job_dir / "simulation_started").exists())
         self.assertIn("%I:sim: Simulation duration:", (job_dir / "simulation.log").read_text(encoding="utf-8"))
+
+    def test_sim_template_skips_simulation_after_preparation_failure(self):
+        temporary_root = Path(tempfile.mkdtemp(prefix="sim preparation failure "))
+        project_dir = temporary_root / "project root"
+        job_dir = temporary_root / "job output"
+        simulation_marker = temporary_root / "simulation-ran"
+        project_dir.mkdir()
+        job_dir.mkdir()
+        rendered_script = self._render_simulation_script(
+            project_dir,
+            job_dir,
+            "touch {}".format(shlex.quote(str(simulation_marker))),
+            pre_sim_commands=["false"],
+        )
+        sim_script = job_dir / "sim.sh"
+        sim_script.write_text(rendered_script, encoding="utf-8")
+
+        completed_process = subprocess.run(["bash", str(sim_script)],
+                                           cwd=temporary_root,
+                                           capture_output=True,
+                                           text=True,
+                                           timeout=10)
+
+        self.assertEqual(1, completed_process.returncode)
+        self.assertFalse(simulation_marker.exists())
+        self.assertFalse((job_dir / "simulation.log").exists())
+        self.assertIn("Simulation preparation failed; skipping main simulation.", completed_process.stdout)
 
     def test_cdc_template_passes_one_command_payload(self):
         template = self._read_repo_file("vendors/cadence/verilog_rtl_cdc_test.sh.template")


### PR DESCRIPTION
## Summary

- normalize host-specific Bazel runfiles paths before hashing VCS compile scripts
- report the exact fingerprint fields behind a compile-cache miss
- serialize cache validation, VCS compilation, and fingerprint updates for shared VCOMP directories across independent processes
- exclude transient VCS license diagnostics and `LM_LICENSE_FILE` routing from compile identity
- skip the simulator command when socket, pre-run, or pre-sim preparation fails

## Root cause

The VCS compile fingerprint included absolute runfiles paths that can change between execution hosts. Independent `bsub` invocations could also validate or overwrite the same fixed VCOMP directory concurrently. In addition, transient stderr from `vcs -ID` and license-server routing could invalidate otherwise compatible builds.

The fingerprint schema is bumped, so the first run after this change intentionally recompiles once before later runs can reuse the cache.

## Validation

- `tests/compile_cache_test.py`: 11 tests passed
- `tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py`: 83 tests passed
- YAPF formatting check passed
- `git diff --check` passed

No BUILD or Starlark files changed, so no redundant local Bazel build was run; the repository CI will run the Bazel and Red Hat-compatible checks.