### PR TITLE
Stabilize VCS tool identity across LSF hosts

### DIFF
--- a/lib/compile_cache.py
+++ b/lib/compile_cache.py
@@ -133,7 +133,7 @@ def compile_fingerprint(project_dir,
                         environment=None):
     """Return the source, generated filelist and compile-mode identity."""
     fingerprint = {
-        "schema_version": 6,
+        "schema_version": 7,
         "compile_script_sha256": _digest_bytes(compile_script.encode("utf-8")),
         "compile_args_sha256": _digest_bytes(_file_bytes(compile_args_path)),
         "environment": dict(sorted((environment or {}).items())),

--- a/lib/simulators/vcs.py
+++ b/lib/simulators/vcs.py
@@ -21,6 +21,16 @@ from .vcs_jobs import IcoInitJob, VsoAskJob, VsoInitJob
 log = logging.getLogger(__name__)
 
 PARTCOMP_MANIFEST_FILENAME = ".rules_verilog_partcomp.json"
+_VCS_COMPILER_VERSION_RE = re.compile(
+    r"(?im)\bCompiler[ \t]+version[ \t]*(?:=|:)?[ \t]*(.+?)(?=[ \t]+Runtime[ \t]+version\b|[;\r\n]|$)")
+
+
+def _stable_vcs_compiler_identity(output):
+    match = _VCS_COMPILER_VERSION_RE.search(output or "")
+    if match is None:
+        return None
+    version = " ".join(match.group(1).split())
+    return "Compiler version = {}".format(version) if version else None
 
 
 def _positive_integer(value):
@@ -175,13 +185,18 @@ class VcsSimulator(SimulatorInterface):
             raise RuntimeError(
                 "Unable to resolve the VCS build ID with '{}'. Set RV_VCS_TOOL_ID to the site VCS release ID: {}".
                 format(shlex.join(command), exc)) from exc
-        identity = result.stdout.strip()
-        if result.returncode != 0 or not identity:
-            diagnostic = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part.strip())
+        diagnostic = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part.strip())
+        if result.returncode != 0:
             raise RuntimeError(
                 "Unable to resolve the VCS build ID with '{}'. Set RV_VCS_TOOL_ID to the site VCS release ID.\n{}".
                 format(shlex.join(command), diagnostic))
+        identity = _stable_vcs_compiler_identity(result.stdout)
+        if identity is None:
+            raise RuntimeError(
+                "Unable to find a stable 'Compiler version' in the output from '{}'. Set RV_VCS_TOOL_ID to the "
+                "site VCS release ID.\n{}".format(shlex.join(command), diagnostic))
         self._vcs_tool_identity = identity
+        log.info("Resolved VCS tool identity: %s", identity)
         return self._vcs_tool_identity
 
     def validate_resolved_options(self):

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -763,16 +763,40 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertEqual(3, simulator.get_partcomp_jobs())
         self.assertIn("jAUTO", simulator.compile_script_for_fingerprint("vcs -fastpartcomp=j3"))
         self.assertEqual("auto", parse_args(["--simulator", "VCS"]).vcs_partcomp_jobs)
+
+    def test_vcs_tool_identity_ignores_runner_and_host_noise(self):
+        options = parse_args(["--simulator", "VCS"])
         with mock.patch.dict(os.environ, {"RV_VCS_TOOL_ID": "VCS Y-2026.03"}):
+            simulator = VcsSimulator(options, DummyRegressionConfig(), None)
             self.assertEqual("VCS Y-2026.03", simulator.get_tool_identity())
 
-        probe = VcsSimulator(options, DummyRegressionConfig(), None)
+        identities = []
+        for host in ("sh-cloud24", "sh-cloud25"):
+            stdout = ("runmod: selected host {}\n"
+                      "Compiler version = VCS X-2025.06-SP2-4_Full64; "
+                      "Runtime version = VCS X-2025.06-SP2-4_Full64; Jul 16 2026\n".format(host))
+            probe = VcsSimulator(options, DummyRegressionConfig(), None)
+            with mock.patch("lib.simulators.vcs.subprocess.run",
+                            return_value=SimpleNamespace(returncode=0,
+                                                         stdout=stdout,
+                                                         stderr="transient license warning\n")) as run:
+                identities.append(probe.get_tool_identity())
+            self.assertEqual(["vcs", "-full64", "-ID"], run.call_args.args[0][-3:])
+
+        self.assertEqual([
+            "Compiler version = VCS X-2025.06-SP2-4_Full64",
+            "Compiler version = VCS X-2025.06-SP2-4_Full64",
+        ], identities)
+
+    def test_vcs_tool_identity_rejects_unstructured_runner_output(self):
+        options = parse_args(["--simulator", "VCS"])
+        simulator = VcsSimulator(options, DummyRegressionConfig(), None)
         with mock.patch("lib.simulators.vcs.subprocess.run",
                         return_value=SimpleNamespace(returncode=0,
-                                                     stdout="VCS Y-2026.03\n",
-                                                     stderr="transient license warning\n")) as run:
-            self.assertEqual("VCS Y-2026.03", probe.get_tool_identity())
-        self.assertEqual(["vcs", "-full64", "-ID"], run.call_args.args[0][-3:])
+                                                     stdout="runmod: selected host sh-cloud24\n",
+                                                     stderr="")):
+            with self.assertRaisesRegex(RuntimeError, "Unable to find a stable 'Compiler version'"):
+                simulator.get_tool_identity()
 
     def test_vcs_partcomp_default_preserves_single_slot_lsf_job(self):
         lsf_environment = {


### PR DESCRIPTION
## Summary

- derive `VCS_TOOL_ID` only from the documented `Compiler version` field emitted by `vcs -ID`
- ignore `runmod` host/banner output, runtime timestamps, and transient stderr
- log the resolved stable compiler identity at info level
- reject unstructured output instead of silently putting unstable text into the compile fingerprint
- bump the compile fingerprint schema so the first recompile establishes a clean baseline

## Root cause

`get_tool_identity()` previously hashed the complete stdout from `runmod vcs -- vcs -full64 -ID`. Separate `bsub -Is` invocations can run on different LSF hosts, and wrapper or runtime output can differ even when both hosts load the same VCS compiler release. That produced a false mismatch in `environment.VCS_TOOL_ID`.

The new identity is limited to a normalized value such as:

```text
Compiler version = VCS X-2025.06-SP2-4_Full64
```

If two hosts actually load different compiler versions, the identities remain different and recompilation is still required.

## Validation

- `tests/compile_cache_test.py`: 11 tests passed
- VCS runtime contract: 85 tests passed
- simulated two LSF hosts with different runner banners and identical compiler versions
- YAPF formatting and `git diff --check` passed

No BUILD or Starlark files changed, so no redundant local Bazel build was run. PR CI will run the repository Bazel and Red Hat-compatible checks.

## Linux station verification

Run these as two separate LSF jobs:

```bash
bsub -Is -n 8 -q syn simmer -t sys_tb:sys_iod_sanity_test --simulator VCS --waves --recompile
bsub -Is -n 8 -q syn simmer -t sys_tb:sys_iod_sanity_test --simulator VCS --waves
```

Both runs should print the same `Resolved VCS tool identity`. The second run should report a VCS compile cache hit.