### PR TITLE
Fix external check_test runfiles execution

### DIFF
--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -24,6 +24,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 ################################################################################
 # rules_verilog lib imports
 from args_parser import parse_args
+import check_test
 from lib.job_lib import Job, JobStatus
 from lib import cmn_logging
 from lib import compile_cache
@@ -742,6 +743,8 @@ class TestJob(Job):
 
         testscript_path = os.path.join(self.job_dir, "sim.sh")
         rerun_script_path = os.path.join(self.job_dir, "rerun.sh")
+        check_test_path = sim_artifacts.materialize_python_script(check_test.__file__,
+                                                                  os.path.join(self.job_dir, "check_test.py"))
 
         sim_working_dir = self.simulator.get_sim_working_dir(self)
         pre_sim_commands = self.simulator.get_pre_sim_commands(self)
@@ -763,7 +766,8 @@ class TestJob(Job):
             'pre_sim_commands': pre_sim_commands,
             'post_sim_commands': post_sim_commands,
             'test_name_seed': getattr(self, 'test_name_seed', None),
-            'check_test_path': sim_artifacts.find_bazel_executable(self.rcfg.proj_dir, "check_test"),
+            'check_test_path': check_test_path,
+            'check_test_python': sys.executable,
             'log_check_args': log_check_args,
         }
 

--- a/bin/templates/sim_template.sh.j2
+++ b/bin/templates/sim_template.sh.j2
@@ -218,12 +218,13 @@ function run_test {
 
  {%- if options.skip_parse_sim_log == 0 %}
     cd "$SIMRESULTS"
+    local log_check_python={{ check_test_python|shell_quote }}
     local log_check_script={{ check_test_path|shell_quote }}
     local simulation_log_file={{ job._log_path|shell_quote }}
 
-    if [ -f "$log_check_script" ] && [ -f "$simulation_log_file" ]; then
+    if [ -x "$log_check_python" ] && [ -f "$log_check_script" ] && [ -f "$simulation_log_file" ]; then
         local log_check_exit_code
-        if "$log_check_script" "$simulation_log_file" {{ log_check_args }}; then
+        if "$log_check_python" "$log_check_script" "$simulation_log_file" {{ log_check_args }}; then
             log_check_exit_code=0
         else
             log_check_exit_code=$?
@@ -234,6 +235,9 @@ function run_test {
                  overall_exit_code=$log_check_exit_code
             fi
         fi
+    elif [ ! -x "$log_check_python" ]; then
+        echo "%E- ERROR: Python interpreter not found or not executable at $log_check_python. Skipping log parsing."
+        overall_exit_code=1
     elif [ ! -f "$log_check_script" ]; then
         echo "%E- ERROR: check_test script not found at $log_check_script. Skipping log parsing."
         overall_exit_code=1

--- a/lib/sim_artifacts.py
+++ b/lib/sim_artifacts.py
@@ -2,7 +2,6 @@
 
 import os
 from pathlib import Path
-import shutil
 
 
 def runfiles_path(path, runfiles_root):
@@ -15,24 +14,16 @@ def runfiles_path(path, runfiles_root):
     return os.path.join("bazel_runfiles_main", relative).replace(os.sep, "/")
 
 
-def find_bazel_executable(project_dir, name):
-    """Find a rules_verilog binary in a main or external Bazel workspace."""
-    project_dir = Path(project_dir)
-    candidates = [
-        project_dir / "bazel-bin/bin" / name,
-        project_dir / "bazel-bin/external/rules_verilog/bin" / name,
-    ]
-    for candidate in candidates:
-        if candidate.is_file():
-            return str(candidate)
-    executable = shutil.which(name)
-    if executable:
-        return executable
-    raise FileNotFoundError("Could not find Bazel executable '{}'; checked {}".format(name, candidates))
-
-
 def write_executable_script(path, content):
     """Write a UTF-8 script and make it executable."""
     path = Path(path)
     path.write_text(content, encoding="utf-8")
     path.chmod(path.stat().st_mode | 0o111)
+
+
+def materialize_python_script(source_path, destination_path):
+    """Copy an importable Python tool into a standalone generated job."""
+    source_path = Path(source_path)
+    destination_path = Path(destination_path)
+    write_executable_script(destination_path, source_path.read_text(encoding="utf-8"))
+    return str(destination_path)

--- a/tests/sim_artifacts_test.py
+++ b/tests/sim_artifacts_test.py
@@ -14,17 +14,19 @@ class SimArtifactsTest(unittest.TestCase):
         self.assertEqual("bazel_runfiles_main/external/vendor/ip.f", sim_artifacts.runfiles_path(path, root))
         self.assertEqual("/outside/ip.f", sim_artifacts.runfiles_path("/outside/ip.f", root))
 
-    def test_find_bazel_executable_supports_main_and_external_workspace(self):
-        project = Path(tempfile.mkdtemp())
-        external = project / "bazel-bin/external/rules_verilog/bin/check_test"
-        external.parent.mkdir(parents=True)
-        external.touch()
-        self.assertEqual(str(external), sim_artifacts.find_bazel_executable(project, "check_test"))
+    def test_materialize_python_script_copies_source_into_job(self):
+        root = Path(tempfile.mkdtemp())
+        source = root / "external repo" / "check_test.py"
+        source.parent.mkdir(parents=True)
+        source.write_text("print('checked')\n", encoding="utf-8")
+        destination = root / "simulation job" / "check_test.py"
+        destination.parent.mkdir(parents=True)
 
-        local = project / "bazel-bin/bin/check_test"
-        local.parent.mkdir(parents=True)
-        local.touch()
-        self.assertEqual(str(local), sim_artifacts.find_bazel_executable(project, "check_test"))
+        result = sim_artifacts.materialize_python_script(source, destination)
+
+        self.assertEqual(str(destination), result)
+        self.assertEqual("print('checked')\n", destination.read_text(encoding="utf-8"))
+        self.assertTrue(destination.stat().st_mode & 0o111)
 
     def test_write_executable_script_sets_execute_bits(self):
         path = Path(tempfile.mkdtemp()) / "rerun.sh"

--- a/tests/vcs_filelist_validation/BUILD
+++ b/tests/vcs_filelist_validation/BUILD
@@ -154,6 +154,7 @@ py_test(
     name = "vcs_runtime_contract_test",
     srcs = ["validate_vcs_runtime_contract_test.py"],
     data = [
+        "//bin:check_test.py",
         "//bin:simmer.py",
         "//bin:templates/rerun_template.sh.j2",
         "//bin:templates/run_waves_template.sh.j2",

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -173,7 +173,9 @@ class VcsRuntimeContractTest(unittest.TestCase):
                                   socket_sidecars=(),
                                   sim_working_dir=None,
                                   pre_run_cmd="",
-                                  pre_sim_commands=()):
+                                  pre_sim_commands=(),
+                                  skip_parse_sim_log=1,
+                                  check_test_path=None):
         jinja_environment = jinja2.Environment(undefined=jinja2.StrictUndefined)
         jinja_environment.filters["shell_quote"] = shlex.quote
         simulation_template = jinja_environment.from_string(self._read_repo_file("bin/templates/sim_template.sh.j2"))
@@ -188,10 +190,11 @@ class VcsRuntimeContractTest(unittest.TestCase):
             ),
         )
         return simulation_template.render(
-            check_test_path=str(Path(project_dir) / "check test"),
+            check_test_path=str(check_test_path or Path(project_dir) / "check test.py"),
+            check_test_python=sys.executable,
             job=test_job,
             log_check_args="",
-            options=SimpleNamespace(skip_parse_sim_log=1),
+            options=SimpleNamespace(skip_parse_sim_log=skip_parse_sim_log),
             post_sim_commands=[],
             pre_run_cmd=pre_run_cmd,
             pre_sim_commands=pre_sim_commands,
@@ -1281,7 +1284,9 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertIn('sidecar_command_template.replace("{socket_file}", socket_endpoint_path)', simmer_source)
         self.assertIn("socket_identity.encode('utf-8')", simmer_source)
         self.assertNotIn("socket_identity.encode('ascii')", simmer_source)
-        self.assertIn("'check_test_path': sim_artifacts.find_bazel_executable", simmer_source)
+        self.assertIn("sim_artifacts.materialize_python_script(check_test.__file__", simmer_source)
+        self.assertIn("'check_test_python': sys.executable", simmer_source)
+        self.assertNotIn("find_bazel_executable", simmer_source)
         self.assertIn("set -m", simulation_template)
         dv_rule = self._read_repo_file("verilog/private/dv.bzl")
         self.assertIn("must match [A-Za-z_][A-Za-z0-9_]*", dv_rule)
@@ -1370,6 +1375,35 @@ class VcsRuntimeContractTest(unittest.TestCase):
         self.assertFalse((job_dir / "simulation_duration_s").exists())
         self.assertFalse((job_dir / "simulation_started").exists())
         self.assertIn("%I:sim: Simulation duration:", (job_dir / "simulation.log").read_text(encoding="utf-8"))
+
+    def test_sim_template_runs_job_local_log_checker_with_python(self):
+        temporary_root = Path(tempfile.mkdtemp(prefix="sim log checker contract "))
+        project_dir = temporary_root / "project root"
+        job_dir = temporary_root / "job output"
+        project_dir.mkdir()
+        job_dir.mkdir()
+        checker = job_dir / "check test.py"
+        checker.write_text(self._read_repo_file("bin/check_test.py"), encoding="utf-8")
+        simulation_command = "printf '%s\\n' 'finish at simulation time' >> \"$TEST_LOG_PATH\""
+        rendered_script = self._render_simulation_script(
+            project_dir,
+            job_dir,
+            simulation_command,
+            skip_parse_sim_log=0,
+            check_test_path=checker,
+        )
+        sim_script = job_dir / "sim.sh"
+        sim_script.write_text(rendered_script, encoding="utf-8")
+
+        completed_process = subprocess.run(["bash", str(sim_script)],
+                                           cwd=temporary_root,
+                                           capture_output=True,
+                                           text=True,
+                                           timeout=10)
+
+        self.assertEqual(0, completed_process.returncode, completed_process.stderr)
+        self.assertTrue((job_dir / "simulation.log.pass").is_file())
+        self.assertNotIn("Cannot exec()", completed_process.stderr)
 
     def test_sim_template_skips_simulation_after_preparation_failure(self):
         temporary_root = Path(tempfile.mkdtemp(prefix="sim preparation failure "))
@@ -1807,6 +1841,8 @@ class VcsRuntimeContractTest(unittest.TestCase):
         waves_template = self._read_repo_file("bin/templates/run_waves_template.sh.j2")
 
         self.assertIn("{{ check_test_path|shell_quote }}", sim_template)
+        self.assertIn("{{ check_test_python|shell_quote }}", sim_template)
+        self.assertIn('"$log_check_python" "$log_check_script"', sim_template)
         self.assertNotIn("bazel-bin/external/rules_verilog", sim_template)
         self.assertIn("SIMMER_WAVE_LAUNCHER", waves_template)
         self.assertNotIn("/global/tools/lsf", waves_template)


### PR DESCRIPTION
## Summary
- materialize the pure-Python log checker in each simulation job
- invoke it with the same Python 3.12 interpreter that runs simmer
- remove dependence on the external-repository py_binary launcher and its unresolved runfiles placeholder
- cover job-local checker execution and path quoting

## Root cause
The simulator completed successfully, but the generated sim.sh executed bazel-bin/external/rules_verilog/bin/check_test directly. In the consuming WORKSPACE that rules_python launcher retained the literal **main** repository placeholder and failed before check_test.py started.

## Validation
- Linux Python 3.12: 94 related unit/runtime-contract tests pass
- YAPF 0.43.0: clean
- Red Hat/Bazel checks: pending CI
