### PR TITLE
Precompute Verilog compile input digests

### DIFF
--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -85,7 +85,12 @@ def _format_simulation_directory_name(vcomp_name, simulator_name, test_name, see
     return result_name + suffix_component
 
 
-def get_bazel_bin():
+def get_bazel_bin(project_dir=None):
+    if project_dir:
+        project_bazel_bin = os.path.join(project_dir, "bazel-bin")
+        if os.path.isdir(project_bazel_bin):
+            return os.path.realpath(project_bazel_bin)
+
     result = subprocess.run(["bazel", "info", "bazel-bin"], capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError("bazel info bazel-bin failed:\n{}\n{}".format(result.stdout, result.stderr))
@@ -257,7 +262,7 @@ class VCompJob(Job):
         options = self.rcfg.options
         relpath, bazel_target = self.bazel_vcomp_target.split(':')
         relpath = relpath[2:] # Remove leading //
-        bazel_bin = get_bazel_bin()
+        bazel_bin = get_bazel_bin(self.rcfg.proj_dir)
         self.bazel_runfiles_main = os.path.join(bazel_bin, relpath, "{}.runfiles".format(bazel_target), "__main__")
         self.bazel_compile_args = self.simulator.get_bazel_compile_args_file(self.bazel_runfiles_main, relpath,
                                                                              bazel_target)
@@ -1020,12 +1025,12 @@ def main(rcfg, options):
         vcomper = VCompJob(rcfg, vcomp, simulator)
         vcomp_jobs[vcomp] = vcomper
 
-        btbj = job_lib.BazelTBJob(rcfg, vcomp, vcomper)
+        btbj = job_lib.BazelTBJob(rcfg, vcomp, vcomper, additional_targets=test_list.keys())
         btbj_jobs.append(btbj)
 
         tests = []
         icfgs = []
-        btcj = job_lib.BazelTestCfgJob(rcfg, test_list.keys(), vcomper)
+        btcj = job_lib.BazelTestCfgJob(rcfg, test_list.keys(), vcomper, prebuilt=True)
         btcj_jobs.append(btcj)
         for test, iterations in test_list.items():
             icfg = rv_utils.IterationCfg(iterations)

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -1009,7 +1009,6 @@ def main(rcfg, options):
     btbj_jobs = []
     trd = []
     webroot_path = resolve_report_root(rcfg, options)
-    report_launcher_path = None
     dynamic_test_plan = simulator.uses_dynamic_test_plan()
     workflow_finalize_failed = False
     coverage_merge_failed = False
@@ -1172,7 +1171,7 @@ def main(rcfg, options):
                 import fcntl
                 fcntl.flock(report_lock, fcntl.LOCK_EX)
                 rrt.render_regression_page()
-                report_launcher_path = rrt.write_run_launcher(os.environ.get("SIMMER_REPORT_URL"))
+                rrt.write_run_launcher(os.environ.get("SIMMER_REPORT_URL"))
             with open(index_lock_path, "w") as report_lock:
                 fcntl.flock(report_lock, fcntl.LOCK_EX)
                 rrt.render_bench_page()
@@ -1195,9 +1194,6 @@ def main(rcfg, options):
 
         for message in getattr(rcfg, "deferred_messages", []):
             log.info(message)
-
-        if report_launcher_path:
-            log.info("Open this regression report: %s", shlex.quote(report_launcher_path))
 
         simulator.cleanup_shared_runtime_artifacts(vcomp_jobs)
         total_failures = sum(failures.values())

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -270,6 +270,7 @@ class VCompJob(Job):
             "dut_instance": "hdl_top.dut",
             "dut_top": "dut",
             "compile_inputs": "",
+            "compile_inputs_digest": "",
         }
         if os.path.isfile(tb_options_path):
             with open(tb_options_path, "r", encoding="utf-8") as filep:
@@ -347,6 +348,10 @@ class VCompJob(Job):
             os.path.join(self.bazel_runfiles_main, self.tb_options["compile_inputs"])
             if self.tb_options["compile_inputs"] else None,
             self.bazel_runfiles_main,
+            compile_inputs_digest_path=os.path.join(
+                self.bazel_runfiles_main,
+                self.tb_options["compile_inputs_digest"],
+            ) if self.tb_options["compile_inputs_digest"] else None,
             **fingerprint_inputs,
         )
         self.simulator.validate_compile_cache_context(self)

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -323,6 +323,29 @@ Compile and simulate a verilog_rtl_library.
 | <a id="verilog_rtl_unit_test-wave_viewer_command"></a>wave_viewer_command |  Allows custom override of waveform viewer command in the event of wrapping via modulefiles. Example override in project's .bazelrc:   build --@rules_verilog//:verilog_rtl_wave_viewer_command="runmod xrun --"   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @rules_verilog//:verilog_rtl_wave_viewer_command |
 
 
+<a id="verilog_test"></a>
+
+## verilog_test
+
+<pre>
+verilog_test(<a href="#verilog_test-name">name</a>, <a href="#verilog_test-data">data</a>, <a href="#verilog_test-deps">deps</a>, <a href="#verilog_test-post_flist_args">post_flist_args</a>, <a href="#verilog_test-pre_flist_args">pre_flist_args</a>, <a href="#verilog_test-shells">shells</a>, <a href="#verilog_test-tool">tool</a>)
+</pre>
+
+Provides a way to run a test against a set of libs.
+
+**ATTRIBUTES**
+
+| Name | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="verilog_test-name"></a>name | A unique name for this target. | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required | |
+| <a id="verilog_test-data"></a>data | Non-verilog dependencies | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="verilog_test-deps"></a>deps | Other verilog libraries this target is dependent upon. All Labels specified here must provide a VerilogInfo provider. | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required | |
+| <a id="verilog_test-post_flist_args"></a>post_flist_args | Commands and arguments after flist arguments | List of strings | optional | [] |
+| <a id="verilog_test-pre_flist_args"></a>pre_flist_args | Commands and arguments before flist arguments | List of strings | optional | [] |
+| <a id="verilog_test-shells"></a>shells | List of verilog_rtl_shell Labels. For each Label, a gumi define will be placed on the command line to use this shell instead of the original module. This requires that the original module was instantiated using \<code>gumi_&lt;module_name&gt; instead of just &lt;module_name&gt;. | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="verilog_test-tool"></a>tool | Label to a single tool to run. Inserted before pre_flist_args if set. Do not duplicate in pre_flist_args. | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+
+
 <a id="verilog_tool_encapsulation"></a>
 
 ## verilog_tool_encapsulation

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -379,7 +379,6 @@ test-config simulation options.
 The following unused or ambiguous interfaces were removed before this workflow
 was merged:
 
-- `verilog_test`; use `verilog_dv_unit_test` or `verilog_rtl_unit_test`.
 - `extra_compile_args_vcs`; use `extra_compile_args` on a VCS testbench.
 - `extra_runtime_args_vcs`; use `extra_runtime_args` on a VCS testbench.
 - the unused CDC `run_template`; use `bash_template`.

--- a/lib/compile_cache.py
+++ b/lib/compile_cache.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import os
+import re
 import tempfile
 
 FINGERPRINT_FILE = ".compile_fingerprint.json"
@@ -99,6 +100,17 @@ def _compile_inputs_manifest_digest(compile_inputs_path):
     return digest.hexdigest()
 
 
+def _read_compile_inputs_digest(path):
+    try:
+        with open(path, "r", encoding="ascii") as filep:
+            digest = filep.read().strip()
+    except OSError as exc:
+        raise RuntimeError("Cannot read Bazel compile input digest '{}': {}".format(path, exc)) from exc
+    if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise RuntimeError("Malformed Bazel compile input digest '{}': {!r}".format(path, digest))
+    return digest
+
+
 def _extra_inputs_digest(paths):
     digest = hashlib.sha256()
     for path in sorted(os.path.abspath(os.fspath(path)) for path in paths if path):
@@ -129,6 +141,7 @@ def compile_fingerprint(project_dir,
                         compile_args_path,
                         compile_inputs_path=None,
                         runfiles_root=None,
+                        compile_inputs_digest_path=None,
                         extra_input_paths=(),
                         environment=None):
     """Return the source, generated filelist and compile-mode identity."""
@@ -139,7 +152,9 @@ def compile_fingerprint(project_dir,
         "environment": dict(sorted((environment or {}).items())),
     }
     if compile_inputs_path:
-        fingerprint["compile_inputs_sha256"] = _compile_inputs_digest(compile_inputs_path, runfiles_root)
+        fingerprint["compile_inputs_sha256"] = (_read_compile_inputs_digest(compile_inputs_digest_path)
+                                                if compile_inputs_digest_path else _compile_inputs_digest(
+                                                    compile_inputs_path, runfiles_root))
         fingerprint["compile_inputs_manifest_sha256"] = _compile_inputs_manifest_digest(compile_inputs_path)
     if extra_input_paths:
         fingerprint["extra_inputs_sha256"] = _extra_inputs_digest(extra_input_paths)

--- a/lib/job_lib.py
+++ b/lib/job_lib.py
@@ -563,20 +563,25 @@ class JobManager():
 
 
 class BazelTBJob(Job):
-    """Runs bazel to build up a tb compile."""
+    """Build the selected testbench and test configs in one Bazel invocation."""
 
-    def __init__(self, rcfg, target, vcomper):
+    def __init__(self, rcfg, target, vcomper, additional_targets=()):
         self.bazel_target = target
+        self.bazel_targets = []
+        if not rcfg.options.no_compile:
+            self.bazel_targets.append(target)
+        self.bazel_targets.extend(additional_targets)
+        self.bazel_targets = list(dict.fromkeys(self.bazel_targets))
         super(BazelTBJob, self).__init__(rcfg, self)
         self.vcomper = vcomper
         if vcomper:
             self.vcomper.add_dependency(self)
 
         self.job_dir = self.vcomper.job_dir # Don't actually need a dir, but jobrunner/manager want it defined
-        if self.rcfg.options.no_compile or self.rcfg.options.no_bazel:
+        if self.rcfg.options.no_bazel or not self.bazel_targets:
             self.main_cmdline = "echo \"Bypassing {} due to --no-compile/--no-bazel\"".format(target)
         else:
-            self.main_cmdline = "bazel build {}".format(target)
+            self.main_cmdline = "bazel build {}".format(" ".join(self.bazel_targets))
 
     def post_run(self):
         super(BazelTBJob, self).post_run()
@@ -591,9 +596,9 @@ class BazelTBJob(Job):
 
 
 class BazelTestCfgJob(Job):
-    """Build all selected test configs for one vcomp in a single Bazel invocation."""
+    """Make selected test config outputs available after vcomp."""
 
-    def __init__(self, rcfg, targets, vcomper):
+    def __init__(self, rcfg, targets, vcomper, prebuilt=False):
         self.bazel_targets = [targets] if isinstance(targets, str) else list(targets)
         self.bazel_target = self.bazel_targets[0]
         super(BazelTestCfgJob, self).__init__(rcfg, self)
@@ -604,6 +609,8 @@ class BazelTestCfgJob(Job):
         self.job_dir = self.vcomper.job_dir # Don't actually need a dir, but jobrunner/manager want it defined
         if self.rcfg.options.no_bazel:
             self.main_cmdline = "echo \"Bypassing test cfg build due to --no-bazel\""
+        elif prebuilt:
+            self.main_cmdline = "echo \"Using test cfg outputs from initial Bazel build\""
         else:
             self.main_cmdline = "bazel build {}".format(" ".join(self.bazel_targets))
 

--- a/tests/compile_cache_test.py
+++ b/tests/compile_cache_test.py
@@ -156,6 +156,42 @@ class CompileCacheTest(unittest.TestCase):
 
         self.assertNotEqual(initial, changed)
 
+    def test_precomputed_compile_input_digest_matches_direct_hash(self):
+        project, _, compile_args = self._project()
+        inventory = project / "compile_inputs.txt"
+        inventory.write_text("source\ttop.sv\n", encoding="utf-8")
+        direct = compile_fingerprint(project, "vcs -f compile.f", compile_args, inventory, project)
+        digest = project / "compile_inputs.sha256"
+        digest.write_text(direct["compile_inputs_sha256"] + "\n", encoding="ascii")
+
+        precomputed = compile_fingerprint(
+            project,
+            "vcs -f compile.f",
+            compile_args,
+            inventory,
+            project,
+            compile_inputs_digest_path=digest,
+        )
+
+        self.assertEqual(direct, precomputed)
+
+    def test_precomputed_compile_input_digest_rejects_malformed_content(self):
+        project, _, compile_args = self._project()
+        inventory = project / "compile_inputs.txt"
+        inventory.write_text("source\ttop.sv\n", encoding="utf-8")
+        digest = project / "compile_inputs.sha256"
+        digest.write_text("not-a-digest\n", encoding="ascii")
+
+        with self.assertRaisesRegex(RuntimeError, "Malformed Bazel compile input digest"):
+            compile_fingerprint(
+                project,
+                "vcs -f compile.f",
+                compile_args,
+                inventory,
+                project,
+                compile_inputs_digest_path=digest,
+            )
+
     def test_fingerprint_rejects_missing_inventory_input(self):
         project, _, compile_args = self._project()
         runfiles = Path(tempfile.mkdtemp())

--- a/tests/job_manager_launch_test.py
+++ b/tests/job_manager_launch_test.py
@@ -119,6 +119,24 @@ class JobManagerLaunchTest(unittest.TestCase):
 
         self.assertEqual("bazel build //pkg:tb", job.main_cmdline)
 
+    def test_bazel_tb_job_batches_test_configs_in_initial_build(self):
+        log = _Logger()
+        rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1, no_compile=False, no_bazel=False), log=log)
+        vcomper = SimpleNamespace(job_dir="vcomp_dir", add_dependency=lambda _job: None)
+
+        job = BazelTBJob(rcfg, "//pkg:tb", vcomper, additional_targets=["//pkg/tests:first", "//pkg/tests:second"])
+
+        self.assertEqual("bazel build //pkg:tb //pkg/tests:first //pkg/tests:second", job.main_cmdline)
+
+    def test_no_compile_still_builds_test_configs(self):
+        log = _Logger()
+        rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1, no_compile=True, no_bazel=False), log=log)
+        vcomper = SimpleNamespace(job_dir="vcomp_dir", add_dependency=lambda _job: None)
+
+        job = BazelTBJob(rcfg, "//pkg:tb", vcomper, additional_targets=["//pkg/tests:first", "//pkg/tests:second"])
+
+        self.assertEqual("bazel build //pkg/tests:first //pkg/tests:second", job.main_cmdline)
+
     def test_no_bazel_bypasses_bazel_build_jobs(self):
         log = _Logger()
         rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1, no_compile=False, no_bazel=True), log=log)
@@ -151,6 +169,21 @@ class JobManagerLaunchTest(unittest.TestCase):
             job.dynamic_args("//pkg/tests:second")
         open_file.assert_called_once_with(os.path.join("/repo", "bazel-bin", "pkg/tests", "second_dynamic_args.py"),
                                           'r')
+
+    def test_prebuilt_test_cfg_job_skips_second_bazel_invocation(self):
+        log = _Logger()
+        rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1, no_bazel=False), log=log)
+        vcomper = SimpleNamespace(
+            job_dir="vcomp_dir",
+            _children=[],
+            add_dependency=lambda _job: None,
+            increase_priority=lambda _priority: None,
+        )
+
+        job = BazelTestCfgJob(rcfg, ["//pkg/tests:first", "//pkg/tests:second"], vcomper, prebuilt=True)
+
+        self.assertNotIn("bazel build", job.main_cmdline)
+        self.assertIn("initial Bazel build", job.main_cmdline)
 
     def test_add_job_wakes_idle_scheduler(self):
         log = _Logger()

--- a/tests/vcs_filelist_validation/validate_vcs_filelist_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_filelist_test.py
@@ -1,4 +1,5 @@
 import ast
+import hashlib
 import json
 import os
 import re
@@ -190,6 +191,15 @@ class VcsFilelistValidationTest(unittest.TestCase):
         self.assertIn("filelist\ttests/vcs_filelist_validation/unit_test_top_vcs.f", compile_inputs)
         self.assertNotIn("filelist\ttests/vcs_filelist_validation/unit_test_top.f\n", compile_inputs)
         self.assertIn("runfile\ttests/vcs_filelist_validation/coverage_hier.cfg", compile_inputs)
+        compile_inputs_digest = read_runfile(vcs_options["compile_inputs_digest"]).strip()
+        expected_digest = hashlib.sha256()
+        for entry in compile_inputs.splitlines():
+            _, relative_path = entry.split("\t", 1)
+            expected_digest.update(entry.encode("utf-8"))
+            expected_digest.update(b"\0")
+            expected_digest.update(find_runfile(relative_path).read_bytes())
+            expected_digest.update(b"\0")
+        self.assertEqual(expected_digest.hexdigest(), compile_inputs_digest)
 
     def test_xcelium_msie_filelists_are_bazel_generated_and_partitioned(self):
         primary_path = "tests/vcs_filelist_validation/dv_tb_xrun_ccf_msie_primary_compile_args.f"

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -57,6 +57,23 @@ class DummyVcompJob:
 
 class VcsRuntimeContractTest(unittest.TestCase):
 
+    def test_get_bazel_bin_prefers_project_symlink(self):
+        with mock.patch("simmer.os.path.isdir", return_value=True), \
+             mock.patch("simmer.os.path.realpath", return_value="/output/bazel-bin") as realpath, \
+             mock.patch("simmer.subprocess.run") as run:
+            self.assertEqual("/output/bazel-bin", simmer.get_bazel_bin("/repo"))
+
+        realpath.assert_called_once_with(os.path.join("/repo", "bazel-bin"))
+        run.assert_not_called()
+
+    def test_get_bazel_bin_falls_back_to_bazel_info(self):
+        completed = SimpleNamespace(returncode=0, stdout="/output/bazel-bin\n", stderr="")
+        with mock.patch("simmer.os.path.isdir", return_value=False), \
+             mock.patch("simmer.subprocess.run", return_value=completed) as run:
+            self.assertEqual("/output/bazel-bin", simmer.get_bazel_bin("/repo"))
+
+        run.assert_called_once_with(["bazel", "info", "bazel-bin"], capture_output=True, text=True)
+
     def test_html_reports_default_to_each_users_regression_directory(self):
         options = parse_args(["--simulator", "VCS"])
         self.assertIsNone(options.report)

--- a/verilog/defs.bzl
+++ b/verilog/defs.bzl
@@ -19,9 +19,11 @@ load(
 )
 load(
     "//verilog/private:verilog.bzl",
+    _verilog_test = "verilog_test",
     _verilog_tool_encapsulation = "verilog_tool_encapsulation",
 )
 
+verilog_test = _verilog_test
 verilog_tool_encapsulation = _verilog_tool_encapsulation
 
 verilog_rtl_cdc_test = _verilog_rtl_cdc_test

--- a/verilog/private/BUILD
+++ b/verilog/private/BUILD
@@ -1,5 +1,13 @@
 # vim: set ft=bzl :
+load("@rules_python//python:defs.bzl", "py_binary")
+
 package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "compile_input_digest",
+    srcs = ["compile_input_digest.py"],
+    python_version = "PY3",
+)
 
 exports_files([
     "rtl.bzl",

--- a/verilog/private/compile_input_digest.py
+++ b/verilog/private/compile_input_digest.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Generate the content digest used by simmer's compile cache."""
+
+import hashlib
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: compile_input_digest MANIFEST OUTPUT")
+
+    manifest_path, output_path = sys.argv[1:]
+    digest = hashlib.sha256()
+    with open(manifest_path, "r", encoding="utf-8") as manifest:
+        for line in manifest:
+            fields = line.rstrip("\n").split("\t", 2)
+            if len(fields) != 3:
+                raise RuntimeError("Malformed compile input digest entry: {!r}".format(line.rstrip("\n")))
+            kind, relative_path, input_path = fields
+            digest.update("{}\t{}".format(kind, relative_path).encode("utf-8"))
+            digest.update(b"\0")
+            with open(input_path, "rb") as input_file:
+                for chunk in iter(lambda: input_file.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            digest.update(b"\0")
+
+    with open(output_path, "w", encoding="ascii") as output:
+        output.write(digest.hexdigest() + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/verilog/private/dv.bzl
+++ b/verilog/private/dv.bzl
@@ -5,7 +5,7 @@ load("//deps:gatesim_modes_list.bzl", "GATESIM_MODES")
 load(":simulators/pldm.bzl", "pldm_dv_backend")
 load(":simulators/vcs.bzl", "vcs_dv_backend")
 load(":simulators/xcelium.bzl", "xcelium_dv_backend", "xcelium_dv_unit_test_impl")
-load(":verilog.bzl", "VerilogInfo", "gather_shell_defines", "get_transitive_srcs", "merge_default_runfiles", "runfiles_relative_short_path", "verilog_input_inventory")
+load(":verilog.bzl", "VerilogInfo", "gather_shell_defines", "get_transitive_srcs", "merge_default_runfiles", "runfiles_relative_short_path", "verilog_input_inventory_records")
 
 DVTestInfo = provider("Runtime configuration for a DV test.", fields = {
     "sim_opts": "Simulation :options to carry forward.",
@@ -562,17 +562,32 @@ def _verilog_dv_tb_impl(ctx):
         ([ctx.file.xcelium_covfile] if ctx.file.xcelium_covfile else []) +
         ([ctx.file.vcs_cm_hier] if ctx.file.vcs_cm_hier else [])
     )
+    compile_input_records = verilog_input_inventory_records(
+        all_deps,
+        compile_input_files,
+        flist_field = compile_config.flist_field,
+        fallback_field = compile_config.fallback_flist_field,
+    )
     ctx.actions.write(
         output = ctx.outputs.compile_inputs,
-        content = verilog_input_inventory(
-            all_deps,
-            compile_input_files,
-            flist_field = compile_config.flist_field,
-            fallback_field = compile_config.fallback_flist_field,
-        ),
+        content = "\n".join([entry for entry, _ in compile_input_records]) + "\n",
+    )
+    digest_manifest = ctx.actions.declare_file(ctx.label.name + "_compile_inputs_digest_manifest.txt")
+    ctx.actions.write(
+        output = digest_manifest,
+        content = "\n".join(["{}\t{}".format(entry, file.path) for entry, file in compile_input_records]) + "\n",
+    )
+    ctx.actions.run(
+        executable = ctx.executable._compile_input_digest,
+        arguments = [digest_manifest.path, ctx.outputs.compile_inputs_digest.path],
+        inputs = depset([digest_manifest] + [file for _, file in compile_input_records]),
+        outputs = [ctx.outputs.compile_inputs_digest],
+        mnemonic = "VerilogCompileInputDigest",
+        progress_message = "Hashing Verilog compile inputs for %{label}",
     )
     tb_options = {
         "compile_inputs": runfiles_relative_short_path(ctx.outputs.compile_inputs),
+        "compile_inputs_digest": runfiles_relative_short_path(ctx.outputs.compile_inputs_digest),
         "dut_instance": ctx.attr.dut_instance,
         "dut_top": ctx.attr.dut_top,
     }
@@ -600,6 +615,7 @@ def _verilog_dv_tb_impl(ctx):
     generated_outputs = [
         ctx.outputs.compile_args,
         ctx.outputs.compile_inputs,
+        ctx.outputs.compile_inputs_digest,
         ctx.outputs.runtime_args,
         ctx.outputs.compile_warning_waivers,
         ctx.outputs.tb_options,
@@ -773,6 +789,11 @@ verilog_dv_tb = rule(
             allow_single_file = True,
             doc = "Template to generate compilation arguments flist.",
         ),
+        "_compile_input_digest": attr.label(
+            default = Label("@rules_verilog//verilog/private:compile_input_digest"),
+            cfg = "exec",
+            executable = True,
+        ),
         "_compile_args_template_pldm_ice": attr.label(
             default = Label("@rules_verilog//vendors/cadence:verilog_dv_tb_compile_args_pldm_ice.f.template"),
             allow_single_file = True,
@@ -788,6 +809,7 @@ verilog_dv_tb = rule(
         "runtime_args": "%{name}_runtime_args.f",
         "compile_args": "%{name}_compile_args.f",
         "compile_inputs": "%{name}_compile_inputs.txt",
+        "compile_inputs_digest": "%{name}_compile_inputs.sha256",
         "compile_args_pldm_ice": "%{name}_compile_args_pldm_ice.f",
         "compile_args_pldm_sa": "%{name}_compile_args_pldm_sa.f",
         "compile_warning_waivers": "%{name}_compile_warning_waivers",

--- a/verilog/private/verilog.bzl
+++ b/verilog/private/verilog.bzl
@@ -99,7 +99,11 @@ def merge_default_runfiles(ctx, files, targets, transitive_files = None):
     ).merge_all([target[DefaultInfo].default_runfiles for target in targets])
 
 def verilog_input_inventory_records(deps, extra_files, flist_field = "transitive_flists", fallback_field = None):
-    """Return stable inventory entries paired with their source files."""
+    """Return stable inventory entries paired with their source files.
+
+    Returns:
+      A sorted list of (inventory entry, File) tuples.
+    """
     records = {}
     sources = get_transitive_srcs([], deps, VerilogInfo, "transitive_sources", allow_other_outputs = True)
     flists = get_transitive_srcs(

--- a/verilog/private/verilog.bzl
+++ b/verilog/private/verilog.bzl
@@ -3,6 +3,10 @@
 
 CUSTOM_SHELL = "custom"
 
+_SHELLS_DOC = """List of verilog_rtl_shell Labels.
+For each Label, a gumi define will be placed on the command line to use this shell instead of the original module.
+This requires that the original module was instantiated using \\`gumi_<module_name> instead of just <module_name>."""
+
 VerilogInfo = provider("Transitive Verilog build inputs.", fields = {
     "transitive_sources": "All source files needed by a target. They are retained for compile input tracking and simulator runfiles.",
     "transitive_flists": "All flists which specify ordering of transitive sources.",
@@ -166,3 +170,70 @@ def flists_to_arguments(deps, provider, field, prefix, separator = "", tool_name
         formatted_args = [" {} {}{}".format(prefix, path_prefix, runfiles_relative_short_path(flist)) for flist in trans]
 
     return separator.join(formatted_args)
+
+def _verilog_test_impl(ctx):
+    trans_srcs = get_transitive_srcs([], ctx.attr.shells + ctx.attr.deps, VerilogInfo, "transitive_sources")
+    srcs_list = trans_srcs.to_list()
+    flists = get_transitive_srcs([], ctx.attr.shells + ctx.attr.deps, VerilogInfo, "transitive_flists")
+    flists_list = flists.to_list()
+
+    content = []
+
+    if ctx.attr.tool:
+        content.append(ctx.attr.tool[DefaultInfo].files_to_run.executable.short_path)
+
+    flists_args = ["-f {}".format(f.short_path) for f in flists_list]
+    content += ctx.attr.pre_flist_args
+
+    for key, value in gather_shell_defines(ctx.attr.shells).items():
+        content.append("  +define+{}{}".format(key, value))
+
+    content += flists_args
+    for dep in ctx.attr.deps:
+        if VerilogInfo in dep and dep[VerilogInfo].last_module:
+            content.append(dep[VerilogInfo].last_module.short_path)
+    content += ctx.attr.post_flist_args
+
+    content = ctx.expand_location(" ".join(content), targets = ctx.attr.data)
+
+    ctx.actions.write(
+        output = ctx.outputs.out,
+        content = content,
+        is_executable = True,
+    )
+
+    if ctx.attr.tool:
+        tool_runfiles = ctx.attr.tool[DefaultInfo].data_runfiles.files
+    else:
+        tool_runfiles = depset([])
+
+    runfiles = ctx.runfiles(files = flists_list + srcs_list + ctx.files.data, transitive_files = tool_runfiles)
+
+    return [DefaultInfo(
+        runfiles = runfiles,
+        executable = ctx.outputs.out,
+    )]
+
+verilog_test = rule(
+    doc = """Provides a way to run a test against a set of libs.""",
+    implementation = _verilog_test_impl,
+    attrs = {
+        "deps": attr.label_list(
+            mandatory = True,
+            doc = "Other verilog libraries this target is dependent upon.\n" +
+                  "All Labels specified here must provide a VerilogInfo provider.",
+        ),
+        "pre_flist_args": attr.string_list(doc = "Commands and arguments before flist arguments"),
+        "post_flist_args": attr.string_list(doc = "Commands and arguments after flist arguments"),
+        "shells": attr.label_list(
+            doc = _SHELLS_DOC,
+        ),
+        "data": attr.label_list(
+            allow_files = True,
+            doc = "Non-verilog dependencies",
+        ),
+        "tool": attr.label(doc = "Label to a single tool to run. Inserted at before pre_flist_args if set. Do not duplicate in pre_flist_args"),
+    },
+    outputs = {"out": "%{name}_run.sh"},
+    test = True,
+)

--- a/verilog/private/verilog.bzl
+++ b/verilog/private/verilog.bzl
@@ -98,17 +98,9 @@ def merge_default_runfiles(ctx, files, targets, transitive_files = None):
         transitive_files = transitive_files,
     ).merge_all([target[DefaultInfo].default_runfiles for target in targets])
 
-def verilog_input_inventory(deps, extra_files, flist_field = "transitive_flists", fallback_field = None):
-    """Return a stable inventory of Verilog compile inputs.
-
-    Args:
-      deps: Targets that provide Verilog inputs.
-      extra_files: Additional compile input files.
-
-    Returns:
-      A newline-delimited compile input inventory.
-    """
-    entries = []
+def verilog_input_inventory_records(deps, extra_files, flist_field = "transitive_flists", fallback_field = None):
+    """Return stable inventory entries paired with their source files."""
+    records = {}
     sources = get_transitive_srcs([], deps, VerilogInfo, "transitive_sources", allow_other_outputs = True)
     flists = get_transitive_srcs(
         [],
@@ -119,12 +111,25 @@ def verilog_input_inventory(deps, extra_files, flist_field = "transitive_flists"
         fallback_attr_name = fallback_field,
     )
     for source in sources.to_list():
-        entries.append("source\t{}".format(runfiles_relative_short_path(source)))
+        records["source\t{}".format(runfiles_relative_short_path(source))] = source
     for flist in flists.to_list():
-        entries.append("filelist\t{}".format(runfiles_relative_short_path(flist)))
+        records["filelist\t{}".format(runfiles_relative_short_path(flist))] = flist
     for extra_file in extra_files:
-        entries.append("runfile\t{}".format(runfiles_relative_short_path(extra_file)))
-    return "\n".join(sorted(depset(entries).to_list())) + "\n"
+        records["runfile\t{}".format(runfiles_relative_short_path(extra_file))] = extra_file
+    return [(entry, records[entry]) for entry in sorted(records)]
+
+def verilog_input_inventory(deps, extra_files, flist_field = "transitive_flists", fallback_field = None):
+    """Return a stable inventory of Verilog compile inputs.
+
+    Args:
+      deps: Targets that provide Verilog inputs.
+      extra_files: Additional compile input files.
+
+    Returns:
+      A newline-delimited compile input inventory.
+    """
+    records = verilog_input_inventory_records(deps, extra_files, flist_field, fallback_field)
+    return "\n".join([entry for entry, _ in records]) + "\n"
 
 def flists_to_arguments(deps, provider, field, prefix, separator = "", tool_name = None, path_prefix = "", fallback_field = None):
     # Emit Bazel short_path entries so generated filelists stay rooted at the


### PR DESCRIPTION
## Summary
- generate the compile-input content digest as a Bazel action
- reuse the small digest file during simmer compile-cache validation
- preserve the existing fingerprint algorithm and fallback for older generated outputs

## Motivation
A confirmed VCS cache hit spent about 50.5 seconds rereading and hashing all RTL/VIP inputs from NFS before the sub-250 ms cache comparison. Bazel now caches that digest and reruns the hashing action only when compile inputs change.

## Validation
- bazel test //:buildifier_diff
- bazel test //tests:compile_cache_test
- targeted VCS filelist digest equivalence test
- YAPF 0.43.0 clean

Full Windows fixture execution retains existing Bash/path failures; Red Hat CI is the authoritative full validation.