### PR TITLE
Clarify VCS incremental compile cache misses

### DIFF
--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -256,6 +256,29 @@ def get_active_job_limit(options, rcfg, simulator):
     return max(1, min(total_tests, requested_jobs))
 
 
+def describe_vcs_compile_reuse_miss(miss_reason):
+    """Return a user-facing explanation for a non-reusable VCS build.
+
+    A fingerprint mismatch is the normal, safe response to changed compile
+    inputs.  It should not be described as a failed cache or a scratch build:
+    VCS still receives the existing VCOMP directory and can reuse its
+    incremental artifacts.  Missing metadata or artifacts need a distinct
+    message because no prior output is available to reuse.
+    """
+    reason = miss_reason or ""
+    prefix = "Compile build fingerprint mismatch"
+    if reason.startswith(prefix):
+        changed = re.search(r"\(changed: ([^)]+)\)", reason)
+        if changed is not None:
+            return "Compile inputs changed ({})".format(changed.group(1))
+        return "Compile inputs changed"
+    if "requires an existing elaborated executable" in reason:
+        return "Reusable VCS compile artifacts are missing or incomplete"
+    if reason.startswith("--no-compile requires "):
+        return "No reusable VCS compile fingerprint exists"
+    return "Reusable VCS compile state is unavailable"
+
+
 # The jobs of the verification compilation and elaboration stages
 class VCompJob(Job):
     # All found vcomp names to prevent collisions
@@ -466,7 +489,12 @@ class VCompJob(Job):
                 lambda: self.simulator.validate_reusable_compile_artifacts(self),
             )
             if not self.compile_cache_hit:
-                log.info("VCS compile cache miss for %s: %s", self, miss_reason)
+                log.info(
+                    "%s; invoking incremental VCS compile for %s",
+                    describe_vcs_compile_reuse_miss(miss_reason),
+                    self,
+                )
+                log.debug("VCS compile reuse unavailable for %s: %s", self, miss_reason)
                 self.main_cmdline = shlex.join(["bash", vcomp_sh_path])
             else:
                 self.main_cmdline = "echo \"Bypassing {} due to VCS compile cache hit\"".format(self)

--- a/tests/simmer_runtime_hardening_test.py
+++ b/tests/simmer_runtime_hardening_test.py
@@ -44,6 +44,24 @@ class _FatalLog:
 
 class SimmerRuntimeHardeningTest(unittest.TestCase):
 
+    def test_vcs_compile_reuse_miss_messages_explain_incremental_behavior(self):
+        self.assertEqual(
+            "Compile inputs changed (compile_inputs_sha256, compile_script_sha256)",
+            simmer.describe_vcs_compile_reuse_miss(
+                "Compile build fingerprint mismatch in /tmp/vcomp "
+                "(changed: compile_inputs_sha256, compile_script_sha256). Recompile this testbench."),
+        )
+        self.assertEqual(
+            "No reusable VCS compile fingerprint exists",
+            simmer.describe_vcs_compile_reuse_miss(
+                "--no-compile requires /tmp/vcomp/.compile_fingerprint.json. Recompile this testbench first."),
+        )
+        self.assertEqual(
+            "Reusable VCS compile artifacts are missing or incomplete",
+            simmer.describe_vcs_compile_reuse_miss(
+                "VCS --no-compile requires an existing elaborated executable at '/tmp/vcomp/simv'"),
+        )
+
     def test_get_bazel_bin_fallback_runs_from_project_directory(self):
         completed = SimpleNamespace(returncode=0, stdout="/output/bazel-bin\n", stderr="")
         with mock.patch("simmer.os.path.isdir", return_value=False), \


### PR DESCRIPTION
## Summary
- replace the ambiguous VCS "compile cache miss" message with the specific compile-input or artifact condition
- state that a miss invokes VCS incremental compilation rather than deleting the VCOMP directory
- cover the user-facing classifications with a focused runtime test

## Validation
- `python tests/simmer_runtime_hardening_test.py`
- `python -m py_compile bin/simmer.py`

The local Windows Bazel launcher cannot resolve `python3.12` from its runfiles manifest, so the Bazel target was not runnable in this workspace.