### PR TITLE
Avoid VCS cache misses from shell environment noise

### DIFF
--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -130,8 +130,10 @@ Run `simmer -h` for all options. MSIE stages must use the same target,
 The default VCS flow automatically reuses unchanged builds:
 
 1. First run builds `<tb>__VCS_VCOMP/simv`.
-2. Later runs compare source content, runfiles, compile arguments, tool identity,
-   environment and required artifacts against the saved fingerprint.
+2. Later runs compare source content, runfiles, compile arguments, the resolved
+   VCS/VSO tool identity and locations, and required artifacts against the saved
+   fingerprint. Interactive shell `PATH`, `LOADEDMODULES` and `MODULEPATH` noise
+   does not invalidate VCS reuse.
 3. A match bypasses VCS. A miss compiles with Partition Compile by default.
 
 The normal command performs this automatic hit-or-compile decision:
@@ -152,8 +154,9 @@ simmer -t <bench>:<test> --simulator VCS --no-compile --no-bazel
 
 `--no-compile` validates a fingerprint of tracked/untracked source state,
 runfile content, the rendered compile script, compile arguments, external
-compile configuration files and the selected tool environment. It fails before
-simulation when the existing compile output does not match the current inputs.
+compile configuration files and the resolved VCS/VSO tool identity and
+locations. It fails before simulation when the existing compile output does not
+match the current inputs.
 
 Use `--recompile` to force a clean VCS compile. It takes precedence over the
 default automatic cache for that invocation.

--- a/lib/simulators/vcs.py
+++ b/lib/simulators/vcs.py
@@ -203,6 +203,12 @@ class VcsSimulator(SimulatorInterface):
 
     def get_compile_fingerprint_inputs(self, vcomp_job):
         inputs = super().get_compile_fingerprint_inputs(vcomp_job)
+        # The rendered VCS command and its resolved tool identity own compiler
+        # selection.  Interactive shell setup is not a compile input: PATH and
+        # module variables routinely contain editors, user utilities, and
+        # module ordering that can change without changing the VCS tool.
+        for key in ("LOADEDMODULES", "MODULEPATH", "PATH"):
+            inputs["environment"].pop(key, None)
         if self.options.vcs_cm_hier:
             inputs["extra_input_paths"].append(self.options.vcs_cm_hier)
         xprop_config = getattr(vcomp_job, "vcs_xprop_config_path", None)

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -703,6 +703,38 @@ run_bounded_process([
             self.assertEqual("xrun release = 25.03-s001", xrun_inputs["environment"]["XCELIUM_TOOL_ID"])
             self.assertNotIn("LM_LICENSE_FILE", xrun_inputs["environment"])
 
+    def test_vcs_compile_fingerprint_ignores_interactive_shell_noise(self):
+        options = parse_args(["--simulator", "VCS"])
+        simulator = VcsSimulator(options, DummyRegressionConfig(), None)
+        simulator._vcs_tool_identity = "VCS X-2025.06-SP2-4"
+        stable_environment = {
+            "VCS_HOME": "/tools/vcs/X-2025.06-SP2-4",
+            "VSO_HOME": "/tools/vso/X-2025.06-SP2-4",
+        }
+        first_session = dict(
+            stable_environment,
+            PATH="/tools/vcs/bin:/home/user/bin:/usr/bin",
+            LOADEDMODULES="vcs/2025.06:gvim/9.1:python/3.12",
+            MODULEPATH="/site/modulefiles:/user/modulefiles",
+        )
+        second_session = dict(
+            stable_environment,
+            PATH="/home/user/.local/bin:/tools/vcs/bin:/usr/bin",
+            LOADEDMODULES="vs_code/1.123:python/3.12:vcs/2025.06",
+            MODULEPATH="/user/modulefiles:/site/modulefiles",
+        )
+
+        with mock.patch.dict(os.environ, first_session, clear=False):
+            first_inputs = simulator.get_compile_fingerprint_inputs(DummyVcompJob())
+        with mock.patch.dict(os.environ, second_session, clear=False):
+            second_inputs = simulator.get_compile_fingerprint_inputs(DummyVcompJob())
+
+        self.assertEqual(first_inputs["environment"], second_inputs["environment"])
+        self.assertEqual(
+            dict(stable_environment, VCS_TOOL_ID="VCS X-2025.06-SP2-4"),
+            first_inputs["environment"],
+        )
+
     def test_shell_templates_quote_runtime_paths(self):
         for template_path in (
                 "bin/templates/sim_template.sh.j2",


### PR DESCRIPTION
## Root cause
VCS compile-reuse fingerprints included the complete interactive `PATH`, `LOADEDMODULES`, and `MODULEPATH`.  On ETX those values contain editor, user-tool, and module-order noise, so an unchanged compiler could be treated as a cache miss.

## Change
- VCS now ignores those session-only variables while retaining `VCS_HOME`, `VSO_HOME`, the resolved VCS tool ID, source/runfile content, compile script, arguments, and external configuration files.
- Document the exact reuse contract.
- Add regression coverage for two differently configured interactive sessions.

## Validation
- `python -m py_compile lib/simulators/vcs.py`
- `python tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py VcsRuntimeContractTest.test_vcs_compile_fingerprint_ignores_interactive_shell_noise`
- `python tests/simmer_runtime_hardening_test.py`

The full VCS contract suite requires its Linux/Bazel runfiles environment; when run directly on Windows it fails on pre-existing POSIX signal and path-separator assumptions.