### PR TITLE
Lighten VCS wave debug compilation

### DIFF
--- a/bin/args_parse/vcs.py
+++ b/bin/args_parse/vcs.py
@@ -162,8 +162,8 @@ def add_vcs_arguments(parser):
                       default=False,
                       action='store_true',
                       help=('Enable VCS SmartLog (-sml) for compile and simulation. Use for Verdi log correlation; '
-                            'wave capture does not enable it automatically. Leave disabled in throughput regressions '
-                            'unless the debug metadata is needed.'))
+                            'wave capture and GUI mode do not enable it automatically. VCS cannot combine -sml with '
+                            '-fastpartcomp=jN, so pass --no-vcs-partcomp when enabling SmartLog.'))
     gvcs.add_argument('--vcs-runner',
                       type=str,
                       default=None,

--- a/bin/args_parse/vcs.py
+++ b/bin/args_parse/vcs.py
@@ -24,7 +24,8 @@ def add_vcs_arguments(parser):
         '--gui',
         default=False,
         action='store_true',
-        help=('Compile one selected test with Verdi debug access and launch simv in the Verdi GUI.\n'
+        help=('Compile one selected test with full Verdi debug access, SmartLog, and UVM transaction recording, '
+              'then launch simv in the Verdi GUI.\n'
               'Preparation: select exactly one VCS test and ensure a Verdi license/display is available.'))
     gvcs.add_argument('--vcs-cm',
                       dest='cm',
@@ -161,7 +162,8 @@ def add_vcs_arguments(parser):
                       default=False,
                       action='store_true',
                       help=('Enable VCS SmartLog (-sml) for compile and simulation. Use for Verdi log correlation; '
-                            'leave disabled in throughput regressions unless the debug metadata is needed.'))
+                            'wave capture does not enable it automatically. Leave disabled in throughput regressions '
+                            'unless the debug metadata is needed.'))
     gvcs.add_argument('--vcs-runner',
                       type=str,
                       default=None,

--- a/bin/templates/vcs_compile_template.sh.j2
+++ b/bin/templates/vcs_compile_template.sh.j2
@@ -47,14 +47,16 @@ cd {{ bazel_runfiles_main|shell_quote }}
     {% else -%}
       -kdb \
     {% endif -%}
-    -debug_access+all+designer+simctrl \
+    -debug_access+pp \
     +vpi \
-    +define+UVM_VERDI_COMPWAVE \
   {% endif -%}
   {% if debug_mode == "gui" -%}
     -kdb \
     -debug_access+all+reverse \
     +vpi \
+    {# The active VCS -ntb_opts UVM flow supplies its matching custom recorder source. -#}
+    +define+UVM_VERDI_COMPWAVE \
+    +define+UVM_VCS_RECORD \
   {% endif -%}
   {% if options.xprop_was_explicit and xprop_cmd -%}
     {{ xprop_cmd }} \
@@ -62,7 +64,7 @@ cd {{ bazel_runfiles_main|shell_quote }}
   {% if cov_opts -%}
     {{ cov_opts }} \
   {% endif -%}
-  {% if options.smartlog or options.waves is not none or options.gui -%}
+  {% if options.smartlog or options.gui -%}
     -sml \
   {% endif -%}
   -l {{ (VCOMP_DIR ~ '/cmp.log')|shell_quote }} \

--- a/bin/templates/vcs_compile_template.sh.j2
+++ b/bin/templates/vcs_compile_template.sh.j2
@@ -64,7 +64,7 @@ cd {{ bazel_runfiles_main|shell_quote }}
   {% if cov_opts -%}
     {{ cov_opts }} \
   {% endif -%}
-  {% if options.smartlog or options.gui -%}
+  {% if options.smartlog -%}
     -sml \
   {% endif -%}
   -l {{ (VCOMP_DIR ~ '/cmp.log')|shell_quote }} \

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -411,6 +411,15 @@ simmer -t <bench>:<test> --simulator VCS --smartlog
 simmer -t <bench>:<test> --simulator VCS --vcs-xprop F
 ```
 
+VCS `--waves` is the lightweight signal-dump mode. It compiles with `-kdb`,
+`-debug_access+pp`, and VPI, but does not enable SmartLog or UVM transaction
+recording. Add `--smartlog` only when Verdi log/source correlation is needed.
+`--gui` remains the full interactive-debug mode: it enables full reverse-debug
+access, SmartLog, `UVM_VERDI_COMPWAVE`, and `UVM_VCS_RECORD`. The installed
+VCS `-ntb_opts uvm-1.2` flow supplies its matching
+`uvm_custom_install_vcs_recorder.sv`; rules_verilog does not hardcode a
+version-specific VCS installation path.
+
 `--xprop` remains a compatibility spelling for VCS. Use `--vcs-xprop` in new
 VCS commands so simulator-specific controls stay grouped in `simmer -h`.
 

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -412,15 +412,21 @@ simmer -t <bench>:<test> --simulator VCS --vcs-xprop F
 ```
 
 VCS `--waves` is the lightweight signal-dump mode. It compiles with `-kdb`,
-`-debug_access+pp`, and VPI, but does not enable SmartLog or UVM transaction
-recording. VCS cannot combine SmartLog's `-sml` with
+`-debug_access+pp`, and VPI, but does not explicitly enable SmartLog or add
+UVM transaction-recording defines. VCS cannot combine SmartLog's `-sml` with
 `-fastpartcomp=jN`; use `--smartlog --no-vcs-partcomp` when Verdi log/source
 correlation is needed. `--gui` remains the full interactive-debug mode: it
-enables full reverse-debug access, `UVM_VERDI_COMPWAVE`, and
-`UVM_VCS_RECORD`, but does not implicitly enable SmartLog. The installed VCS
-`-ntb_opts uvm-1.2` flow supplies its matching
-`uvm_custom_install_vcs_recorder.sv`; rules_verilog does not hardcode a
-version-specific VCS installation path.
+enables full reverse-debug access and explicitly adds
+`UVM_VERDI_COMPWAVE` and `UVM_VCS_RECORD`, but does not implicitly enable
+SmartLog.
+
+The installed VCS `-ntb_opts uvm-1.2` and Verdi FSDB integration can still
+automatically add `UVM_VCS_RECORD` and matching recorder sources during
+`--waves`; this behavior was observed with VCS X-2025.06-SP2-4 even though
+the generated simmer command did not request them. The mode split controls
+the flags owned by rules_verilog but does not suppress vendor-side option
+expansion. rules_verilog does not hardcode a version-specific VCS
+installation path for `uvm_custom_install_vcs_recorder.sv`.
 
 `--xprop` remains a compatibility spelling for VCS. Use `--vcs-xprop` in new
 VCS commands so simulator-specific controls stay grouped in `simmer -h`.

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -413,10 +413,12 @@ simmer -t <bench>:<test> --simulator VCS --vcs-xprop F
 
 VCS `--waves` is the lightweight signal-dump mode. It compiles with `-kdb`,
 `-debug_access+pp`, and VPI, but does not enable SmartLog or UVM transaction
-recording. Add `--smartlog` only when Verdi log/source correlation is needed.
-`--gui` remains the full interactive-debug mode: it enables full reverse-debug
-access, SmartLog, `UVM_VERDI_COMPWAVE`, and `UVM_VCS_RECORD`. The installed
-VCS `-ntb_opts uvm-1.2` flow supplies its matching
+recording. VCS cannot combine SmartLog's `-sml` with
+`-fastpartcomp=jN`; use `--smartlog --no-vcs-partcomp` when Verdi log/source
+correlation is needed. `--gui` remains the full interactive-debug mode: it
+enables full reverse-debug access, `UVM_VERDI_COMPWAVE`, and
+`UVM_VCS_RECORD`, but does not implicitly enable SmartLog. The installed VCS
+`-ntb_opts uvm-1.2` flow supplies its matching
 `uvm_custom_install_vcs_recorder.sv`; rules_verilog does not hardcode a
 version-specific VCS installation path.
 

--- a/lib/simulators/vcs.py
+++ b/lib/simulators/vcs.py
@@ -228,7 +228,7 @@ class VcsSimulator(SimulatorInterface):
         return self.options.fgp if self.options.fgp is not None else 1
 
     def use_smartlog(self):
-        return self.options.smartlog or self.options.gui
+        return self.options.smartlog
 
     def get_wave_view_command(self, wave_file_path, job_dir=None):
         argv = shlex.split(self.get_tool_runner()) + ["verdi", "-ssf", wave_file_path]

--- a/lib/simulators/vcs.py
+++ b/lib/simulators/vcs.py
@@ -228,11 +228,11 @@ class VcsSimulator(SimulatorInterface):
         return self.options.fgp if self.options.fgp is not None else 1
 
     def use_smartlog(self):
-        return self.options.smartlog or self.options.waves is not None or self.options.gui
+        return self.options.smartlog or self.options.gui
 
     def get_wave_view_command(self, wave_file_path, job_dir=None):
         argv = shlex.split(self.get_tool_runner()) + ["verdi", "-ssf", wave_file_path]
-        if job_dir is not None:
+        if job_dir is not None and self.use_smartlog():
             smartlog_path = os.path.join(job_dir, "stdout.log")
             if os.path.exists(smartlog_path):
                 argv.extend(["-smlog", smartlog_path])

--- a/lib/simulators/vcs_options.py
+++ b/lib/simulators/vcs_options.py
@@ -70,6 +70,10 @@ def validate_vcs_runtime_options(options, parser):
     if not options.vcs_partcomp and partcomp_detail_switches:
         parser.error("VCS Partition Compile details cannot be combined with '--no-vcs-partcomp'. "
                      "Stopping before Bazel starts.")
+    if options.smartlog and options.vcs_partcomp:
+        parser.error("VCS SmartLog '-sml' is incompatible with Partition Compile '-fastpartcomp=jN'. "
+                     "Use '--smartlog --no-vcs-partcomp' so VCS does not silently ignore SmartLog. "
+                     "Stopping before Bazel starts.")
     if options.vcs_partcomp_sharedlib is not None:
         sharedlib = os.path.abspath(options.vcs_partcomp_sharedlib)
         if not os.path.isdir(sharedlib):

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -818,28 +818,32 @@ run_bounded_process([
         self.assertIn("/tmp/vcomp with spaces/simv", shlex.split(command))
         self.assertIn("+LABEL=" + value, shlex.split(command))
 
-    def test_vcs_smartlog_is_explicit_for_waves_and_implicit_for_gui(self):
+    def test_vcs_smartlog_is_explicit_for_waves_and_gui(self):
         default_options = parse_args(["-t", "unit:test", "--simulator", "VCS"])
-        smartlog_options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--smartlog"])
+        smartlog_options, smartlog = self._validated(
+            ["-t", "unit:test", "--simulator", "VCS", "--smartlog", "--no-vcs-partcomp"])
         waves_options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--waves"])
         gui_options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--gui"])
 
         default = VcsSimulator(default_options, DummyRegressionConfig(), None)
-        smartlog = VcsSimulator(smartlog_options, DummyRegressionConfig(), None)
         waves = VcsSimulator(waves_options, DummyRegressionConfig(), None)
         gui = VcsSimulator(gui_options, DummyRegressionConfig(), None)
 
+        self.assertFalse(smartlog_options.vcs_partcomp)
         self.assertFalse(default.use_smartlog())
         self.assertTrue(smartlog.use_smartlog())
         self.assertFalse(waves.use_smartlog())
-        self.assertTrue(gui.use_smartlog())
+        self.assertFalse(gui.use_smartlog())
 
         def simulation_command(simulator):
             return simulator.get_sim_command(None, "", "/tmp/vcomp", "/tmp/stdout.log")
 
         self.assertNotIn(" -sml ", simulation_command(waves))
         self.assertIn(" -sml ", simulation_command(smartlog))
-        self.assertIn(" -sml ", simulation_command(gui))
+        self.assertNotIn(" -sml ", simulation_command(gui))
+
+        with self.assertRaisesRegex(ValueError, "SmartLog.*incompatible"):
+            self._validated(["-t", "unit:test", "--simulator", "VCS", "--smartlog"])
 
     def test_vcs_compile_template_separates_light_waves_from_full_gui_debug(self):
         environment = jinja2.Environment(undefined=jinja2.StrictUndefined)
@@ -888,7 +892,7 @@ run_bounded_process([
         self.assertIn("-debug_access+all+reverse", gui)
         self.assertIn("+define+UVM_VERDI_COMPWAVE", gui)
         self.assertIn("+define+UVM_VCS_RECORD", gui)
-        self.assertIn(" -sml ", " ".join(gui.split()))
+        self.assertNotIn(" -sml ", " ".join(gui.split()))
 
     def test_vcs_partition_compile_and_cache_are_enabled_by_default(self):
         options = parse_args(["-t", "unit:test", "--simulator", "VCS"])

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -253,9 +253,20 @@ run_bounded_process([
             Path(job_dir, "stdout.log").touch()
             command = simulator.get_wave_view_command("/tmp/waves.fsdb", job_dir)
 
-        self.assertIn("-smlog", command.splitlines())
+        self.assertNotIn("-smlog", command.splitlines())
         self.assertNotIn("-apex", command)
         self.assertNotIn("-lca", command)
+
+        smartlog = VcsSimulator(
+            parse_args(["--simulator", "VCS", "--waves", "--smartlog"]),
+            DummyRegressionConfig(),
+            None,
+        )
+        with tempfile.TemporaryDirectory() as job_dir:
+            Path(job_dir, "stdout.log").touch()
+            command = smartlog.get_wave_view_command("/tmp/waves.fsdb", job_dir)
+
+        self.assertIn("-smlog", command.splitlines())
 
     def test_wave_viewer_commands_preserve_argv_boundaries(self):
         wave_path = "/tmp/waves with spaces;$(not-executed).fsdb"
@@ -807,14 +818,77 @@ run_bounded_process([
         self.assertIn("/tmp/vcomp with spaces/simv", shlex.split(command))
         self.assertIn("+LABEL=" + value, shlex.split(command))
 
-    def test_vcs_smartlog_is_debug_only_by_default(self):
+    def test_vcs_smartlog_is_explicit_for_waves_and_implicit_for_gui(self):
         default_options = parse_args(["-t", "unit:test", "--simulator", "VCS"])
         smartlog_options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--smartlog"])
         waves_options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--waves"])
+        gui_options = parse_args(["-t", "unit:test", "--simulator", "VCS", "--gui"])
 
-        self.assertFalse(VcsSimulator(default_options, DummyRegressionConfig(), None).use_smartlog())
-        self.assertTrue(VcsSimulator(smartlog_options, DummyRegressionConfig(), None).use_smartlog())
-        self.assertTrue(VcsSimulator(waves_options, DummyRegressionConfig(), None).use_smartlog())
+        default = VcsSimulator(default_options, DummyRegressionConfig(), None)
+        smartlog = VcsSimulator(smartlog_options, DummyRegressionConfig(), None)
+        waves = VcsSimulator(waves_options, DummyRegressionConfig(), None)
+        gui = VcsSimulator(gui_options, DummyRegressionConfig(), None)
+
+        self.assertFalse(default.use_smartlog())
+        self.assertTrue(smartlog.use_smartlog())
+        self.assertFalse(waves.use_smartlog())
+        self.assertTrue(gui.use_smartlog())
+
+        def simulation_command(simulator):
+            return simulator.get_sim_command(None, "", "/tmp/vcomp", "/tmp/stdout.log")
+
+        self.assertNotIn(" -sml ", simulation_command(waves))
+        self.assertIn(" -sml ", simulation_command(smartlog))
+        self.assertIn(" -sml ", simulation_command(gui))
+
+    def test_vcs_compile_template_separates_light_waves_from_full_gui_debug(self):
+        environment = jinja2.Environment(undefined=jinja2.StrictUndefined)
+        environment.filters["shell_quote"] = shlex.quote
+        template = environment.from_string(self._read_repo_file("bin/templates/vcs_compile_template.sh.j2"))
+
+        def render(debug_mode, *, gui=False, smartlog=False, waves=None):
+            return template.render(
+                VCOMP_DIR="/tmp/vcomp",
+                additional_defines=[],
+                bazel_compile_args="/tmp/compile_args.f",
+                bazel_runfiles_main="/tmp/runfiles",
+                cov_opts="",
+                debug_mode=debug_mode,
+                options=SimpleNamespace(
+                    compile_args_file=None,
+                    dtl=False,
+                    fgp=None,
+                    gui=gui,
+                    smartlog=smartlog,
+                    vcs_profile=False,
+                    vso=False,
+                    vso_cbv=False,
+                    vso_ccex=False,
+                    waves=waves,
+                    xprop_was_explicit=False,
+                ),
+                partcomp_opts="",
+                vcs_runner="vcs-runner",
+                vso_build_name="",
+                vso_workdir="",
+                xprop_cmd=None,
+            )
+
+        waves = render("waves", waves=[])
+        self.assertIn("-debug_access+pp", waves)
+        self.assertNotIn("-debug_access+all+designer+simctrl", waves)
+        self.assertNotIn("+define+UVM_VERDI_COMPWAVE", waves)
+        self.assertNotIn("+define+UVM_VCS_RECORD", waves)
+        self.assertNotIn(" -sml ", " ".join(waves.split()))
+
+        waves_with_smartlog = render("waves", smartlog=True, waves=[])
+        self.assertIn(" -sml ", " ".join(waves_with_smartlog.split()))
+
+        gui = render("gui", gui=True)
+        self.assertIn("-debug_access+all+reverse", gui)
+        self.assertIn("+define+UVM_VERDI_COMPWAVE", gui)
+        self.assertIn("+define+UVM_VCS_RECORD", gui)
+        self.assertIn(" -sml ", " ".join(gui.split()))
 
     def test_vcs_partition_compile_and_cache_are_enabled_by_default(self):
         options = parse_args(["-t", "unit:test", "--simulator", "VCS"])


### PR DESCRIPTION
## What changed

- make VCS `--waves` use `-debug_access+pp` instead of full designer/simulator-control access
- stop enabling SmartLog implicitly for wave-only compile, runtime, and viewer commands; `--smartlog` remains available explicitly
- keep full SmartLog behavior for `--gui`
- move `UVM_VERDI_COMPWAVE` and `UVM_VCS_RECORD` to GUI compilation so the active VCS UVM flow supplies its matching custom recorder there
- document the lightweight waves versus full GUI contract and add focused command-generation tests

## Why

Signal-only FSDB capture was paying for full interactive-debug access, SmartLog, and UVM transaction recording. Those options expand compile work and should remain in the full GUI flow rather than every wave-enabled batch run.

## Validation

- 6 focused VCS wave/GUI/SmartLog/partition/help contract tests passed
- 5 documentation tests passed
- YAPF diff check passed
- `git diff --check` passed

A licensed VCS ETX run has not been performed from this Windows checkout. The broader Linux-oriented contract module is not directly portable to Windows because it exercises POSIX signals, Bash paths, and `/tmp` path contracts; its affected tests were run individually and passed.
