### PR TITLE
Fix VCS compile reuse and signal-only wave overhead

### DIFF
--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -566,12 +566,17 @@ class VCompJob(Job):
                     first_unwaived_warning = None
                     warnings_found = 0
                     warning_regex = re.compile(base_warning_pattern)
+                    ignored_warning_lines = self.simulator.get_ignored_compile_warning_line_numbers(self.log_path)
 
                     with open(self.log_path, 'r', encoding='utf-8', errors='ignore') as logp:
-                        for warning_line in logp:
+                        for line_number, warning_line in enumerate(logp, start=1):
                             if not warning_regex.search(warning_line):
                                 continue
                             warnings_found += 1
+                            if line_number in ignored_warning_lines:
+                                log.debug("Ignoring benign compile warning at line %d: %s", line_number,
+                                          warning_line.strip())
+                                continue
                             warning_line_stripped = warning_line.strip()
                             if warning_line_stripped and not any(
                                     waiver.search(warning_line_stripped) for waiver in warning_waivers):

--- a/bin/templates/vcs_compile_template.sh.j2
+++ b/bin/templates/vcs_compile_template.sh.j2
@@ -47,8 +47,7 @@ cd {{ bazel_runfiles_main|shell_quote }}
     {% else -%}
       -kdb \
     {% endif -%}
-    -debug_access+pp \
-    +vpi \
+    -debug_access \
   {% endif -%}
   {% if debug_mode == "gui" -%}
     -kdb \

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -158,6 +158,12 @@ compile configuration files and the resolved VCS/VSO tool identity and
 locations. It fails before simulation when the existing compile output does not
 match the current inputs.
 
+VCS compile logs can contain a GNU make future-mtime warning when an NFS
+timestamp is less than 100 ms ahead of the execution host. Simmer treats that
+specific small skew and its paired clock-skew summary as benign. A larger skew
+or a clock-skew summary without a small future-mtime detail still fails the
+compile and prevents fingerprint reuse.
+
 Use `--recompile` to force a clean VCS compile. It takes precedence over the
 default automatic cache for that invocation.
 
@@ -411,22 +417,17 @@ simmer -t <bench>:<test> --simulator VCS --smartlog
 simmer -t <bench>:<test> --simulator VCS --vcs-xprop F
 ```
 
-VCS `--waves` is the lightweight signal-dump mode. It compiles with `-kdb`,
-`-debug_access+pp`, and VPI, but does not explicitly enable SmartLog or add
-UVM transaction-recording defines. VCS cannot combine SmartLog's `-sml` with
+VCS `--waves` is the lightweight signal-dump mode. It compiles with `-kdb`
+and the base `-debug_access`, but does not enable VPI, SmartLog, or UVM
+transaction-recording defines. VCS cannot combine SmartLog's `-sml` with
 `-fastpartcomp=jN`; use `--smartlog --no-vcs-partcomp` when Verdi log/source
 correlation is needed. `--gui` remains the full interactive-debug mode: it
 enables full reverse-debug access and explicitly adds
 `UVM_VERDI_COMPWAVE` and `UVM_VCS_RECORD`, but does not implicitly enable
 SmartLog.
 
-The installed VCS `-ntb_opts uvm-1.2` and Verdi FSDB integration can still
-automatically add `UVM_VCS_RECORD` and matching recorder sources during
-`--waves`; this behavior was observed with VCS X-2025.06-SP2-4 even though
-the generated simmer command did not request them. The mode split controls
-the flags owned by rules_verilog but does not suppress vendor-side option
-expansion. rules_verilog does not hardcode a version-specific VCS
-installation path for `uvm_custom_install_vcs_recorder.sv`.
+The signal-only mode avoids the callback, driver, class, and VPI capabilities
+used for transaction-aware debug. GUI mode keeps VPI and UVM recording.
 
 `--xprop` remains a compatibility spelling for VCS. Use `--vcs-xprop` in new
 VCS commands so simulator-specific controls stay grouped in `simmer -h`.
@@ -444,9 +445,9 @@ simmer -t <bench>:<test> --simulator VCS \
 ```
 
 Successful wave runs create an executable `run_waves.sh` beside `waves.fsdb`.
-It launches the standard Verdi FSDB viewer with `verdi -ssf`; it does not force
-the Apex/VERDI-ULTRA or LCA feature tiers. Sites using LSF can provide a
-launcher without editing the generated script:
+It launches the Verdi FSDB viewer with `verdi -apex -ssf`; it does not add
+`-lca`. Sites using LSF can provide a launcher without editing the generated
+script:
 
 ```bash
 SIMMER_WAVE_LAUNCHER="bsub -I -q syn" ./run_waves.sh

--- a/lib/simulators/base.py
+++ b/lib/simulators/base.py
@@ -167,6 +167,10 @@ class SimulatorInterface(abc.ABC):
         # Example: return {'warning_regex': r"\*W.*"}
         pass
 
+    def get_ignored_compile_warning_line_numbers(self, log_path):
+        """Return one-based compile-log line numbers that are safe to ignore."""
+        return set()
+
     @abc.abstractmethod
     def get_gui_command_options(self):
         """Return simulator-specific options required for GUI mode."""

--- a/lib/simulators/vcs.py
+++ b/lib/simulators/vcs.py
@@ -22,6 +22,7 @@ from .vcs_jobs import IcoInitJob, VsoAskJob, VsoInitJob
 log = logging.getLogger(__name__)
 
 PARTCOMP_MANIFEST_FILENAME = ".rules_verilog_partcomp.json"
+_MAX_BENIGN_MAKE_CLOCK_SKEW_SECONDS = 0.1
 _VCS_COMPILER_VERSION_RE = re.compile(
     r"(?im)\bCompiler[ \t]+version[ \t]*(?:=|:)?[ \t]*(.+?)(?=[ \t]+Runtime[ \t]+version\b|[;\r\n]|$)")
 
@@ -231,7 +232,7 @@ class VcsSimulator(SimulatorInterface):
         return self.options.smartlog
 
     def get_wave_view_command(self, wave_file_path, job_dir=None):
-        argv = shlex.split(self.get_tool_runner()) + ["verdi", "-ssf", wave_file_path]
+        argv = shlex.split(self.get_tool_runner()) + ["verdi", "-apex", "-ssf", wave_file_path]
         if job_dir is not None and self.use_smartlog():
             smartlog_path = os.path.join(job_dir, "stdout.log")
             if os.path.exists(smartlog_path):
@@ -598,6 +599,26 @@ class VcsSimulator(SimulatorInterface):
 
     def get_log_parsing_info(self):
         return {'warning_regex': r"(?i)^(?:\s*(?:Warning|Error)(?:-|\s*:)|.+:\s*(?:warning|error):).*"}
+
+    def get_ignored_compile_warning_line_numbers(self, log_path):
+        future_mtime_regex = re.compile(r"(?i)\bmake(?:\[\d+\])?:\s*warning:\s*file .+ has modification time "
+                                        r"([0-9]+(?:\.[0-9]+)?)\s+s in the future\b")
+        clock_skew_regex = re.compile(r"(?i)\bmake(?:\[\d+\])?:\s*warning:\s*clock skew detected\.\s*"
+                                      r"your build may be incomplete\.")
+        benign_future_mtime_lines = set()
+        clock_skew_summary_lines = set()
+
+        with open(log_path, 'r', encoding='utf-8', errors='ignore') as logp:
+            for line_number, line in enumerate(logp, start=1):
+                match = future_mtime_regex.search(line)
+                if match and float(match.group(1)) < _MAX_BENIGN_MAKE_CLOCK_SKEW_SECONDS:
+                    benign_future_mtime_lines.add(line_number)
+                if clock_skew_regex.search(line):
+                    clock_skew_summary_lines.add(line_number)
+
+        if benign_future_mtime_lines:
+            return benign_future_mtime_lines | clock_skew_summary_lines
+        return set()
 
     def get_gui_command_options(self):
         # Enable Verdi debug features along with DVE/Verdi GUI

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -239,14 +239,14 @@ run_bounded_process([
         self.assertEqual("unit_tb__VCS__smoke__42__i2",
                          simmer._format_simulation_directory_name("unit_tb", "VCS", "smoke", 42, 2, ""))
 
-    def test_vcs_wave_viewer_does_not_force_apex_or_lca_licenses(self):
+    def test_vcs_wave_viewer_uses_apex_without_lca(self):
         options = parse_args(["--simulator", "VCS", "--waves"])
         simulator = VcsSimulator(options, DummyRegressionConfig(), None)
 
         command = simulator.get_wave_view_command("/tmp/waves.fsdb")
 
-        self.assertEqual(["runmod", "vcs", "--", "verdi", "-ssf", "/tmp/waves.fsdb"], command.splitlines())
-        self.assertNotIn("-apex", command)
+        self.assertEqual(["runmod", "vcs", "--", "verdi", "-apex", "-ssf", "/tmp/waves.fsdb"], command.splitlines())
+        self.assertIn("-apex", command)
         self.assertNotIn("-lca", command)
 
         with tempfile.TemporaryDirectory() as job_dir:
@@ -254,7 +254,7 @@ run_bounded_process([
             command = simulator.get_wave_view_command("/tmp/waves.fsdb", job_dir)
 
         self.assertNotIn("-smlog", command.splitlines())
-        self.assertNotIn("-apex", command)
+        self.assertIn("-apex", command)
         self.assertNotIn("-lca", command)
 
         smartlog = VcsSimulator(
@@ -274,7 +274,7 @@ run_bounded_process([
         xcelium = XceliumSimulator(parse_args(["--simulator", "XRUN", "--waves"]), DummyRegressionConfig(), None)
 
         self.assertEqual(
-            ["runmod", "vcs", "--", "verdi", "-ssf", wave_path],
+            ["runmod", "vcs", "--", "verdi", "-apex", "-ssf", wave_path],
             vcs.get_wave_view_command(wave_path).splitlines(),
         )
         self.assertEqual(
@@ -879,7 +879,9 @@ run_bounded_process([
             )
 
         waves = render("waves", waves=[])
-        self.assertIn("-debug_access+pp", waves)
+        self.assertIn("-debug_access", waves)
+        self.assertNotIn("-debug_access+pp", waves)
+        self.assertNotIn("+vpi", waves)
         self.assertNotIn("-debug_access+all+designer+simctrl", waves)
         self.assertNotIn("+define+UVM_VERDI_COMPWAVE", waves)
         self.assertNotIn("+define+UVM_VCS_RECORD", waves)
@@ -890,6 +892,7 @@ run_bounded_process([
 
         gui = render("gui", gui=True)
         self.assertIn("-debug_access+all+reverse", gui)
+        self.assertIn("+vpi", gui)
         self.assertIn("+define+UVM_VERDI_COMPWAVE", gui)
         self.assertIn("+define+UVM_VCS_RECORD", gui)
         self.assertNotIn(" -sml ", " ".join(gui.split()))
@@ -2523,8 +2526,9 @@ run_bounded_process([
 
         with mock.patch.object(simmer, "log", mock.Mock()), \
              mock.patch.object(simulator, "record_compile_artifacts"), \
-             mock.patch.object(simmer.compile_cache, "write_compile_fingerprint"):
+             mock.patch.object(simmer.compile_cache, "write_compile_fingerprint") as write_fingerprint:
             vcomp.post_run()
+        vcomp.write_compile_fingerprint = write_fingerprint
         return vcomp
 
     def test_vcs_unwaived_compile_warning_blocks_simulation(self):
@@ -2557,6 +2561,35 @@ run_bounded_process([
         )
 
         self.assertEqual(JobStatus.PASSED, vcomp.jobstatus)
+
+    def test_vcs_tiny_make_clock_skew_allows_compile_fingerprint(self):
+        vcomp = self._run_vcs_compile_post_run(
+            "make[1]: Warning: File 'filelist.hsopt.objs' has modification time 0.0061 s in the future\n"
+            "make[1]: warning:  Clock skew detected.  Your build may be incomplete.",
+            [],
+        )
+
+        self.assertEqual(JobStatus.PASSED, vcomp.jobstatus)
+        vcomp.write_compile_fingerprint.assert_called_once_with(vcomp.job_dir, vcomp.compile_fingerprint)
+
+    def test_vcs_material_make_clock_skew_still_fails(self):
+        vcomp = self._run_vcs_compile_post_run(
+            "make[1]: Warning: File 'filelist.hsopt.objs' has modification time 0.1 s in the future\n"
+            "make[1]: warning:  Clock skew detected.  Your build may be incomplete.",
+            [],
+        )
+
+        self.assertEqual(JobStatus.FAILED, vcomp.jobstatus)
+        vcomp.write_compile_fingerprint.assert_not_called()
+
+    def test_vcs_unexplained_make_clock_skew_still_fails(self):
+        vcomp = self._run_vcs_compile_post_run(
+            "make[1]: warning:  Clock skew detected.  Your build may be incomplete.",
+            [],
+        )
+
+        self.assertEqual(JobStatus.FAILED, vcomp.jobstatus)
+        vcomp.write_compile_fingerprint.assert_not_called()
 
     def test_xcelium_warning_format_remains_compatible_with_tb_waivers(self):
         options = parse_args(["-t", "unit:test", "--simulator", "XRUN"])

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -2813,7 +2813,7 @@ run_bounded_process([
     def test_simmer_log_and_profile_performance_contracts(self):
         source = self._read_repo_file("bin/simmer.py")
 
-        self.assertIn("for warning_line in logp", source)
+        self.assertIn("for line_number, warning_line in enumerate(logp, start=1)", source)
         self.assertNotIn("text = logp.read()", source)
         self.assertNotIn('subprocess.run(["chmod", "-R"', source)
         self.assertIn("completed without simulation log", source)


### PR DESCRIPTION
## Summary

- treat GNU make future-mtime skew below 100 ms, plus its paired clock-skew summary, as benign so successful VCS compiles can write their reuse fingerprint
- keep larger or unexplained clock skew fatal
- make signal-only VCS waves use `-kdb -debug_access` without `+vpi`; GUI mode keeps full VPI/UVM recording
- generate VCS wave viewers as `verdi -apex -ssf ...`
- retain the complete compile filelist because all VIPs are required

## Root cause

A successful incremental VCS compile emitted a 6.1 ms NFS future-mtime warning. Simmer promoted that warning to a compile failure, skipped writing `.compile_fingerprint.json`, and invoked VCS again on every later run.

The signal-only wave mode also enabled `-debug_access+pp` and VPI capabilities that are unnecessary for FSDB post-process signal debug and can trigger UVM recorder integration.

## Validation

- 9 focused VCS runtime-contract tests: passed
- 5 documentation tests: passed
- 25 runtime-hardening tests: passed (5 POSIX-only skipped on Windows)
- YAPF diff: clean
- `git diff --check`: passed

Full X-2025.06-SP2-4 compile validation is intentionally pending because the user is currently using the ETX/XinAnRiver workspace. The next ETX check should confirm that `uvm_custom_install_vcs_recorder.sv` is absent from signal-only wave compilation, the FSDB is generated, and the next unchanged simmer invocation reports a fingerprint cache hit.