### PR TITLE
Handle wrapped VCS clock skew warnings

### DIFF
--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -160,9 +160,10 @@ match the current inputs.
 
 VCS compile logs can contain a GNU make future-mtime warning when an NFS
 timestamp is less than 100 ms ahead of the execution host. Simmer treats that
-specific small skew and its paired clock-skew summary as benign. A larger skew
-or a clock-skew summary without a small future-mtime detail still fails the
-compile and prevents fingerprint reuse.
+specific small skew and its paired clock-skew summary as benign, including when
+GNU make wraps `in the future` across a backslash-continued line. A larger skew
+or a clock-skew summary without a complete small future-mtime detail still
+fails the compile and prevents fingerprint reuse.
 
 Use `--recompile` to force a clean VCS compile. It takes precedence over the
 default automatic cache for that invocation.

--- a/lib/simulators/vcs.py
+++ b/lib/simulators/vcs.py
@@ -664,17 +664,30 @@ class VcsSimulator(SimulatorInterface):
 
     def get_ignored_compile_warning_line_numbers(self, log_path):
         future_mtime_regex = re.compile(r"(?i)\bmake(?:\[\d+\])?:\s*warning:\s*file .+ has modification time "
-                                        r"([0-9]+(?:\.[0-9]+)?)\s+s in the future\b")
+                                        r"([0-9]+(?:\.[0-9]+)?)\s+s in the(?:\s+future\b|(?P<continued>\s*\\\s*$))")
+        future_mtime_continuation_regex = re.compile(r"(?i)^\s*future\b")
         clock_skew_regex = re.compile(r"(?i)\bmake(?:\[\d+\])?:\s*warning:\s*clock skew detected\.\s*"
                                       r"your build may be incomplete\.")
         benign_future_mtime_lines = set()
         clock_skew_summary_lines = set()
+        continued_future_mtime = None
 
         with open(log_path, 'r', encoding='utf-8', errors='ignore') as logp:
             for line_number, line in enumerate(logp, start=1):
+                if continued_future_mtime is not None:
+                    warning_line_number, skew_seconds = continued_future_mtime
+                    if (future_mtime_continuation_regex.search(line)
+                            and skew_seconds < _MAX_BENIGN_MAKE_CLOCK_SKEW_SECONDS):
+                        benign_future_mtime_lines.add(warning_line_number)
+                    continued_future_mtime = None
+
                 match = future_mtime_regex.search(line)
-                if match and float(match.group(1)) < _MAX_BENIGN_MAKE_CLOCK_SKEW_SECONDS:
-                    benign_future_mtime_lines.add(line_number)
+                if match:
+                    skew_seconds = float(match.group(1))
+                    if match.group("continued") is not None:
+                        continued_future_mtime = (line_number, skew_seconds)
+                    elif skew_seconds < _MAX_BENIGN_MAKE_CLOCK_SKEW_SECONDS:
+                        benign_future_mtime_lines.add(line_number)
                 if clock_skew_regex.search(line):
                     clock_skew_summary_lines.add(line_number)
 

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -2739,9 +2739,42 @@ run_bounded_process([
         self.assertEqual(JobStatus.PASSED, vcomp.jobstatus)
         vcomp.write_compile_fingerprint.assert_called_once_with(vcomp.job_dir, vcomp.compile_fingerprint)
 
+    def test_vcs_tiny_multiline_make_clock_skew_allows_compile_fingerprint(self):
+        vcomp = self._run_vcs_compile_post_run(
+            "make[1]: Warning: File 'filelist.hsopt.objs' has modification time 0.0075 s in the \\\n"
+            "future\n"
+            "make[1]: warning:  Clock skew detected.  Your build may be incomplete.",
+            [],
+        )
+
+        self.assertEqual(JobStatus.PASSED, vcomp.jobstatus)
+        vcomp.write_compile_fingerprint.assert_called_once_with(vcomp.job_dir, vcomp.compile_fingerprint)
+
     def test_vcs_material_make_clock_skew_still_fails(self):
         vcomp = self._run_vcs_compile_post_run(
             "make[1]: Warning: File 'filelist.hsopt.objs' has modification time 0.1 s in the future\n"
+            "make[1]: warning:  Clock skew detected.  Your build may be incomplete.",
+            [],
+        )
+
+        self.assertEqual(JobStatus.FAILED, vcomp.jobstatus)
+        vcomp.write_compile_fingerprint.assert_not_called()
+
+    def test_vcs_material_multiline_make_clock_skew_still_fails(self):
+        vcomp = self._run_vcs_compile_post_run(
+            "make[1]: Warning: File 'filelist.hsopt.objs' has modification time 0.1 s in the \\\n"
+            "future\n"
+            "make[1]: warning:  Clock skew detected.  Your build may be incomplete.",
+            [],
+        )
+
+        self.assertEqual(JobStatus.FAILED, vcomp.jobstatus)
+        vcomp.write_compile_fingerprint.assert_not_called()
+
+    def test_vcs_incomplete_multiline_make_clock_skew_still_fails(self):
+        vcomp = self._run_vcs_compile_post_run(
+            "make[1]: Warning: File 'filelist.hsopt.objs' has modification time 0.0075 s in the \\\n"
+            "unexpected continuation\n"
             "make[1]: warning:  Clock skew detected.  Your build may be incomplete.",
             [],
         )


### PR DESCRIPTION
## Summary

- recognize GNU make future-mtime warnings when `in the future` is split across a backslash-continued line
- retain the existing strict `< 0.1s` benign-skew threshold
- keep malformed continuations and material clock skew as failures
- document the wrapped warning behavior

## Root cause

VCS emitted `make` warnings as two physical lines (`in the \\` followed by `future`). The warning gate matched only the single-line form, so a successful compile was marked failed and its compile fingerprint was not saved.

## Validation

- 6 focused VCS clock-skew contract tests passed
- documentation tests: 5 passed
- YAPF 0.43.0
- `git diff --check`