### PR TITLE
Speed up cached simmer startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The generated FSDB controls are:
 | simmer argument | Effect |
 |-----------------|--------|
 | `--waves [scope ...]` | Enables FSDB, glitch capture, and force/release/deposit metadata; no scope defaults to `hdl_top`. |
-| `--wave-depth N` | Applies depth `N` to every selected scope. The default captures all hierarchy. |
+| `--wave-depth N` | Applies depth `N` to every selected scope. The default is 10; use 999 for all hierarchy. |
 | `--wave-start NS` | Starts dumping at an absolute, non-negative simulation time in ns. |
 | `--wave-end NS` | Stops dumping at an absolute time in ns; it must be greater than `--wave-start`. |
 | `--wave-tcl FILE` | Uses a VCS UCLI file instead of generated scope, depth, and time commands. |

--- a/bin/args_parse/common.py
+++ b/bin/args_parse/common.py
@@ -63,9 +63,9 @@ def add_debug_arguments(parser):
                        '--wave-depth',
                        parent='--waves',
                        type=int,
-                       default=999,
-                       help=('Set generated probe hierarchy depth (default: 999, effectively all hierarchy). '
-                             'Reduce it to limit waveform size. Requires --waves.'))
+                       default=10,
+                       help=('Set generated probe hierarchy depth (default: 10). '
+                             'Use 999 for effectively all hierarchy. Requires --waves.'))
     debug_group.add_argument('--verbosity',
                              type=str,
                              default=None,

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -648,11 +648,13 @@ Use `--simmer-profile` to print phase and job timings after the summary:
 simmer -t <bench>:<test> --simulator VCS --simmer-profile
 ```
 
-The profile includes discovery, each Bazel command, Bazel external-repository
-events, TB setup, VCS compile, test config builds, simulation jobs, job
-directories, and commands. Repository rows are shown as `external_repo: NAME`
-at the finest granularity Bazel records. A cached repository has no fetch or
-repository-rule event, so it does not appear in that invocation.
+The profile includes discovery, each Bazel command, Bazel build-phase markers,
+Bazel external-repository events, TB setup, VCS compile, test config builds,
+simulation jobs, job directories, and commands. The scheduled testbench build
+also leaves `bazel_tb_profile.json` in its VCOMP directory for deeper analysis.
+Repository rows are shown as `external_repo: NAME` at the finest granularity
+Bazel records. A cached repository has no fetch or repository-rule event, so it
+does not appear in that invocation.
 
 Generated unit-test scripts print the failed command, line and exit code before
 they close. For a script launched in a temporary terminal, keep the window open

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -653,8 +653,10 @@ Bazel external-repository events, TB setup, VCS compile, test config builds,
 simulation jobs, job directories, and commands. The scheduled testbench build
 also leaves `bazel_tb_profile.json` in its VCOMP directory for deeper analysis.
 Repository rows are shown as `external_repo: NAME` at the finest granularity
-Bazel records. A cached repository has no fetch or repository-rule event, so it
-does not appear in that invocation.
+Bazel records. Overlapping events for one repository are merged so these rows
+approximate wall-clock time instead of double-counting nested work. A cached
+repository has no fetch or repository-rule event, so it does not appear in that
+invocation.
 
 Generated unit-test scripts print the failed command, line and exit code before
 they close. For a script launched in a temporary terminal, keep the window open

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -758,14 +758,14 @@ seed and original simulator options. Run it directly from any directory. Set
 ## Saving disk space
 
 - Discovery metadata is cached under `.simmer/cache/` and can be deleted at any
-  time. `--no-bazel` accepts it only while BUILD, `.bzl`, MODULE/WORKSPACE and
-  Bazel configuration files (including `.bazelignore`) remain unchanged.
-  Git-backed `local_repository` dependencies use the Git index to track only
-  Bazel metadata instead of walking large source trees. A
-  `new_local_repository` with `build_file` or `build_file_content` tracks that
-  injected metadata without scanning the vendor source root. If another local
-  repository cannot be inspected safely, simmer disables discovery reuse and
-  records the repository path and reason in `discovery_manifest.json`.
+  time. The cache tracks BUILD-prefixed files, `.bzl`, MODULE/WORKSPACE and
+  Bazel configuration files (including `.bazelignore`) inside the main
+  workspace. External IP/VIP repositories are intentionally excluded; run
+  `bazel clean` after changing them.
+- When discovery is cached and the existing TB runfiles and test-config outputs
+  are still present, simmer reuses those outputs instead of repeating
+  `bazel build`. A changed workspace metadata file invalidates discovery and
+  rebuilds them; `bazel clean` removes the outputs and also forces a rebuild.
 - Passing tests are removed by default. `--nt` intentionally retains them.
 - Do not enable waves, coverage, SmartLog, ICO artifacts or `--nt` in routine
   throughput regressions.

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -520,7 +520,10 @@ VCS wave dumping supports FSDB only.
 
 ### FSDB probe and viewer flow
 
-The default FSDB command probes `hdl_top`. Limit scope and time when possible:
+The default FSDB command probes `hdl_top` to depth 10. VCS wave builds retain
+`-kdb` and base debug access for source-code visibility, while FSDB contains HDL
+signals rather than the UVM VIP class hierarchy. Limit scope and time further
+when possible:
 
 ```bash
 simmer -t <bench>:<test> --simulator VCS \
@@ -539,8 +542,9 @@ SIMMER_WAVE_LAUNCHER="bsub -I -q syn" ./run_waves.sh
 
 The generated UCLI script uses the file ID returned by `dump -file`, so it does
 not assume `FSDB0` when another dump file is already open. The default
-`--wave-depth 999` maps to UCLI `-depth 0`, which is the documented unlimited
-hierarchy depth; explicit smaller depths are preserved.
+`--wave-depth` is 10. An explicit `--wave-depth 999` maps to UCLI `-depth 0`,
+which is the documented unlimited hierarchy depth; other explicit depths are
+preserved.
 
 VCS FSDB waves enable glitch and force information by default. Simmer passes
 `+fsdb+glitch=0` and `+fsdb+force` to `simv`; generated UCLI also runs

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -756,6 +756,12 @@ seed and original simulator options. Run it directly from any directory. Set
 - Discovery metadata is cached under `.simmer/cache/` and can be deleted at any
   time. `--no-bazel` accepts it only while BUILD, `.bzl`, MODULE/WORKSPACE and
   Bazel configuration files (including `.bazelignore`) remain unchanged.
+  Git-backed `local_repository` dependencies use the Git index to track only
+  Bazel metadata instead of walking large source trees. A
+  `new_local_repository` with `build_file` or `build_file_content` tracks that
+  injected metadata without scanning the vendor source root. If another local
+  repository cannot be inspected safely, simmer disables discovery reuse and
+  records the repository path and reason in `discovery_manifest.json`.
 - Passing tests are removed by default. `--nt` intentionally retains them.
 - Do not enable waves, coverage, SmartLog, ICO artifacts or `--nt` in routine
   throughput regressions.

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -26,7 +26,10 @@ py_library(
 py_library(
     name = "job_lib",
     srcs = ["job_lib.py"],
-    deps = [":runtime_options"],
+    deps = [
+        ":bazel_profile",
+        ":runtime_options",
+    ],
 )
 
 py_library(

--- a/lib/bazel_profile.py
+++ b/lib/bazel_profile.py
@@ -4,7 +4,7 @@ import json
 import re
 
 _REPOSITORY_RE = re.compile(r"(?:@@?|external[/\\])([A-Za-z0-9._+~-]+)")
-_REPOSITORY_NAME_RE = re.compile(r"repository(?: rule)?[=: ]+([A-Za-z0-9._+~-]+)", re.IGNORECASE)
+_REPOSITORY_NAME_RE = re.compile(r"repository(?: rule[=: ]+|[=:]+)([A-Za-z0-9._+~-]+)", re.IGNORECASE)
 
 
 def _repository_name(event, searchable):
@@ -42,13 +42,29 @@ def repository_timings(profile_path):
         if not repository or repository == "BazelRepositoryModule":
             continue
 
-        duration_s, count = totals.get(repository, (0.0, 0))
-        totals[repository] = (duration_s + event["dur"] / 1_000_000.0, count + 1)
+        intervals, unpositioned_duration_us, count = totals.get(repository, ([], 0, 0))
+        timestamp_us = event.get("ts")
+        if isinstance(timestamp_us, (int, float)):
+            intervals.append((timestamp_us, timestamp_us + event["dur"]))
+        else:
+            unpositioned_duration_us += event["dur"]
+        totals[repository] = (intervals, unpositioned_duration_us, count + 1)
 
-    return sorted(
-        [(duration_s, repository, count) for repository, (duration_s, count) in totals.items()],
-        reverse=True,
-    )
+    aggregated = []
+    for repository, (intervals, unpositioned_duration_us, count) in totals.items():
+        positioned_duration_us = 0
+        interval_end_us = None
+        for start_us, end_us in sorted(intervals):
+            if interval_end_us is None or start_us > interval_end_us:
+                positioned_duration_us += end_us - start_us
+                interval_end_us = end_us
+            elif end_us > interval_end_us:
+                positioned_duration_us += end_us - interval_end_us
+                interval_end_us = end_us
+        duration_s = (positioned_duration_us + unpositioned_duration_us) / 1_000_000.0
+        aggregated.append((duration_s, repository, count))
+
+    return sorted(aggregated, reverse=True)
 
 
 def phase_timings(profile_path):

--- a/lib/bazel_profile.py
+++ b/lib/bazel_profile.py
@@ -49,3 +49,34 @@ def repository_timings(profile_path):
         [(duration_s, repository, count) for repository, (duration_s, count) in totals.items()],
         reverse=True,
     )
+
+
+def phase_timings(profile_path):
+    """Return elapsed time between Bazel build-phase markers."""
+    with open(profile_path, encoding="utf-8") as profile_file:
+        events = json.load(profile_file).get("traceEvents", [])
+
+    markers = []
+    profile_end_us = 0
+    for event in events:
+        timestamp_us = event.get("ts")
+        if not isinstance(timestamp_us, (int, float)):
+            continue
+        duration_us = event.get("dur", 0)
+        if not isinstance(duration_us, (int, float)):
+            duration_us = 0
+        profile_end_us = max(profile_end_us, timestamp_us + duration_us)
+
+        if "build phase marker" not in str(event.get("cat", "")).lower():
+            continue
+        name = str(event.get("name", "")).strip()
+        if name:
+            markers.append((timestamp_us, name))
+
+    timings = []
+    markers = sorted(set(markers))
+    for index, (timestamp_us, name) in enumerate(markers):
+        next_timestamp_us = markers[index + 1][0] if index + 1 < len(markers) else profile_end_us
+        duration_s = max(0, next_timestamp_us - timestamp_us) / 1_000_000.0
+        timings.append((duration_s, name))
+    return timings

--- a/lib/job_lib.py
+++ b/lib/job_lib.py
@@ -8,12 +8,14 @@ import ast
 import datetime
 import enum
 import os
+import shlex
 import signal
 import socket
 import subprocess
 import threading
 import time
 
+from lib import bazel_profile
 from lib.runtime_options import normalize_test_runtime_options
 
 
@@ -1192,20 +1194,45 @@ class BazelTBJob(Job):
             self.vcomper.add_dependency(self)
 
         self.job_dir = self.vcomper.job_dir # Don't actually need a dir, but jobrunner/manager want it defined
+        self.bazel_profile_path = None
         if self.rcfg.options.no_bazel:
             self.main_cmdline = "echo \"Bypassing {} due to --no-compile/--no-bazel\"".format(target)
         elif not self.bazel_targets:
             self.main_cmdline = "echo \"Using cached or discovery-built Bazel outputs for {}\"".format(target)
         else:
-            self.main_cmdline = "bazel build {}".format(" ".join(self.bazel_targets))
+            command = ["bazel", "build"]
+            if getattr(self.rcfg.options, "simmer_profile", False):
+                self.bazel_profile_path = os.path.join(self.job_dir, "bazel_tb_profile.json")
+                command.append("--profile={}".format(self.bazel_profile_path))
+            command.extend(self.bazel_targets)
+            self.main_cmdline = shlex.join(command)
+
+    def pre_run(self):
+        super(BazelTBJob, self).pre_run()
+        if self.bazel_profile_path and os.path.exists(self.bazel_profile_path):
+            os.remove(self.bazel_profile_path)
 
     def post_run(self):
         super(BazelTBJob, self).post_run()
+        self._collect_bazel_profile()
         if self.job_lib.returncode == 0:
             self.jobstatus = JobStatus.PASSED
         else:
             self.jobstatus = JobStatus.FAILED
             self.log.error("%s failed. Log in %s", self, os.path.join(self.job_dir, "stderr.log"))
+
+    def _collect_bazel_profile(self):
+        if not self.bazel_profile_path or not os.path.exists(self.bazel_profile_path):
+            return
+        try:
+            for duration, phase in bazel_profile.phase_timings(self.bazel_profile_path):
+                self.rcfg.profile_events.append((duration, "bazel_build_phase: {}".format(phase), self.bazel_target))
+            for duration, repository, event_count in bazel_profile.repository_timings(self.bazel_profile_path):
+                detail = "build; {} repository event(s)".format(event_count)
+                self.rcfg.profile_events.append((duration, "external_repo: {}".format(repository), detail))
+            self.rcfg.profile_events.append((0.0, "bazel_build_profile", self.bazel_profile_path))
+        except (OSError, ValueError, TypeError) as exc:
+            self.log.warning("Could not parse Bazel profile %s: %s", self.bazel_profile_path, exc)
 
     def __repr__(self):
         return 'Bazel("{}")'.format(self.bazel_target)

--- a/lib/job_lib.py
+++ b/lib/job_lib.py
@@ -1187,6 +1187,9 @@ class BazelTBJob(Job):
         self.bazel_targets.extend(additional_targets)
         self.bazel_targets = list(dict.fromkeys(self.bazel_targets))
         prebuilt_targets = set(prebuilt_targets)
+        if getattr(rcfg, "use_cached_discovery", False):
+            prebuilt_targets.update(target for target in self.bazel_targets
+                                    if self._cached_target_output_exists(rcfg.proj_dir, target))
         self.bazel_targets = [target for target in self.bazel_targets if target not in prebuilt_targets]
         super(BazelTBJob, self).__init__(rcfg, self)
         self.vcomper = vcomper
@@ -1206,6 +1209,13 @@ class BazelTBJob(Job):
                 command.append("--profile={}".format(self.bazel_profile_path))
             command.extend(self.bazel_targets)
             self.main_cmdline = shlex.join(command)
+
+    def _cached_target_output_exists(self, project_dir, target):
+        package, target_name = target.split(":", 1)
+        output_dir = os.path.join(project_dir, "bazel-bin", package[2:])
+        if target == self.bazel_target:
+            return os.path.isdir(os.path.join(output_dir, "{}.runfiles".format(target_name), "__main__"))
+        return os.path.isfile(os.path.join(output_dir, "{}_dynamic_args.py".format(target_name)))
 
     def pre_run(self):
         super(BazelTBJob, self).pre_run()

--- a/lib/regression.py
+++ b/lib/regression.py
@@ -41,50 +41,15 @@ DISCOVERY_ROOT_FILES = {
 }
 DISCOVERY_MAX_ARG_CHARS = 100000
 DISCOVERY_MAX_SOURCE_RETRIES = 2
-DISCOVERY_LOCAL_REPOSITORY_MAX_DEPTH = 32
-DISCOVERY_LOCAL_REPOSITORY_MAX_DIRS = 4096
-DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES = 50000
-DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES = 4096
-DISCOVERY_LOCAL_REPOSITORY_MAX_DECLARATION_BYTES = 4 * 1024 * 1024
 DISCOVERY_GIT_METADATA_PATHS = (
     "BUILD",
     "BUILD.bazel",
-    ":(glob)**/BUILD",
-    ":(glob)**/BUILD.bazel",
+    ":(glob)**/BUILD*",
     ":(glob)**/*.bzl",
     ":(glob)**/*.bazelrc",
     ":(glob)**/.bazelrc*",
     *sorted(DISCOVERY_ROOT_FILES),
 )
-
-
-class _DiscoveryDependencyScanLimit(Exception):
-
-    def __init__(self, project_paths, reason):
-        super().__init__(reason.get("detail", "local repository metadata scan failed"))
-        self.project_paths = project_paths
-        self.reason = reason
-
-
-class _UnresolvedLocalRepositoryDeclaration(Exception):
-
-    def __init__(self, metadata_path, detail, line=None):
-        super().__init__(detail)
-        self.metadata_path = metadata_path
-        self.detail = detail
-        self.line = line
-
-
-class _LocalRepositoryMetadataScanLimit(Exception):
-
-    def __init__(self, repository_root, limit_name, maximum=None, detail=None):
-        if detail is None:
-            detail = "local repository metadata scan exceeded {}={}".format(limit_name, maximum)
-        super().__init__(detail)
-        self.repository_root = repository_root
-        self.limit_name = limit_name
-        self.maximum = maximum
-        self.detail = detail
 
 
 def resolve_report_generation(report_option, total_simulations):
@@ -330,16 +295,7 @@ class RegressionConfig():
     def _discovery_dependency_manifest(self):
         submodule_state = self._git_submodule_state()
         project_root = os.path.realpath(self.proj_dir)
-        cacheable = True
-        uncacheable_reason = None
-        try:
-            dependency_paths = sorted(set(self._iter_discovery_dependency_paths(submodule_state)))
-        except _DiscoveryDependencyScanLimit as exc:
-            dependency_paths = sorted(set(exc.project_paths))
-            cacheable = False
-            uncacheable_reason = dict(exc.reason)
-            if uncacheable_reason.get("path"):
-                uncacheable_reason["path"] = self._manifest_relative_path(uncacheable_reason["path"], project_root)
+        dependency_paths = sorted(set(self._iter_discovery_dependency_paths(submodule_state)))
         files = []
         for path in dependency_paths:
             relative_path = self._manifest_relative_path(path, project_root)
@@ -350,15 +306,13 @@ class RegressionConfig():
                 digest = "missing"
             files.append({"path": relative_path, "sha256": digest})
         manifest = {
-            "schema_version": 4,
-            "cacheable": cacheable,
+            "schema_version": 5,
+            "cacheable": True,
             "allow_no_run": bool(self.options.allow_no_run),
             "discovery_query": self._build_vcomp_discovery_query(),
             "git_submodules": submodule_state,
             "files": files,
         }
-        if uncacheable_reason is not None:
-            manifest["uncacheable_reason"] = uncacheable_reason
         return manifest
 
     def _git_submodule_state(self):
@@ -374,7 +328,7 @@ class RegressionConfig():
     @staticmethod
     def _is_discovery_dependency(relative_path):
         filename = os.path.basename(relative_path)
-        return (filename in ("BUILD", "BUILD.bazel") or filename.endswith(".bzl") or filename.startswith(".bazelrc")
+        return (filename.startswith("BUILD") or filename.endswith(".bzl") or filename.startswith(".bazelrc")
                 or filename.endswith(".bazelrc") or relative_path in DISCOVERY_ROOT_FILES)
 
     def _bazelrc_dependency_paths(self):
@@ -415,255 +369,6 @@ class RegressionConfig():
         with self._discovery_cache_lock(exclusive=True):
             self.dict_to_json(manifest, "discovery_manifest.json")
 
-    @staticmethod
-    def _ast_expression_name(expression):
-        if isinstance(expression, ast.Name):
-            return expression.id
-        if isinstance(expression, ast.Attribute):
-            return expression.attr
-        return None
-
-    @staticmethod
-    def _literal_string(expression):
-        if isinstance(expression, ast.Constant) and isinstance(expression.value, str):
-            return expression.value
-        return None
-
-    def _repository_build_file_path(self, metadata_path, label, line):
-        if label.startswith("@"):
-            raise _UnresolvedLocalRepositoryDeclaration(
-                metadata_path,
-                "external new_local_repository build_file labels are unsupported",
-                line,
-            )
-        if label.startswith("//"):
-            target = label[2:]
-            if ":" not in target:
-                raise _UnresolvedLocalRepositoryDeclaration(
-                    metadata_path,
-                    "new_local_repository build_file must use an explicit //package:file label",
-                    line,
-                )
-            package, filename = target.split(":", 1)
-            return os.path.join(self.proj_dir, package.replace("/", os.sep), filename)
-        if label.startswith(":"):
-            return os.path.join(os.path.dirname(metadata_path), label[1:])
-        return os.path.join(os.path.dirname(metadata_path), label)
-
-    def _local_repository_dependencies(self, metadata_path):
-        try:
-            with open(metadata_path, "r", encoding="utf-8", errors="surrogateescape") as filep:
-                source = filep.read(DISCOVERY_LOCAL_REPOSITORY_MAX_DECLARATION_BYTES + 1)
-            if len(source) > DISCOVERY_LOCAL_REPOSITORY_MAX_DECLARATION_BYTES:
-                raise _UnresolvedLocalRepositoryDeclaration(
-                    metadata_path,
-                    "Bazel metadata file containing local repository declarations exceeds {} bytes".format(
-                        DISCOVERY_LOCAL_REPOSITORY_MAX_DECLARATION_BYTES),
-                )
-            tree = ast.parse(source, filename=metadata_path)
-        except OSError:
-            return [], []
-        except (SyntaxError, ValueError) as exc:
-            if "local_repository" in source or "new_local_repository" in source:
-                raise _UnresolvedLocalRepositoryDeclaration(
-                    metadata_path,
-                    "could not parse Bazel metadata containing local repository declarations",
-                    getattr(exc, "lineno", None),
-                )
-            return [], []
-
-        repository_paths = []
-        build_file_paths = []
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            repository_function_names = {"local_repository", "new_local_repository"}
-            rule_name = self._ast_expression_name(node.func)
-            if rule_name not in repository_function_names:
-                repo_rule = None
-                if node.args:
-                    repo_rule = node.args[0]
-                for keyword in node.keywords:
-                    if keyword.arg == "repo_rule":
-                        repo_rule = keyword.value
-                        break
-                rule_name = self._ast_expression_name(repo_rule)
-            if rule_name not in repository_function_names:
-                continue
-
-            keywords = {keyword.arg: keyword.value for keyword in node.keywords if keyword.arg is not None}
-            if rule_name == "new_local_repository":
-                if "build_file_content" in keywords:
-                    continue
-                build_file = self._literal_string(keywords.get("build_file"))
-                if build_file is None:
-                    raise _UnresolvedLocalRepositoryDeclaration(
-                        metadata_path,
-                        "new_local_repository must provide a literal build_file or build_file_content",
-                        getattr(node, "lineno", None),
-                    )
-                build_file_paths.append(
-                    self._repository_build_file_path(metadata_path, build_file, getattr(node, "lineno", None)))
-                continue
-
-            repository_path = self._literal_string(keywords.get("path"))
-            if repository_path is None:
-                raise _UnresolvedLocalRepositoryDeclaration(
-                    metadata_path,
-                    "local_repository path is not a string literal",
-                    getattr(node, "lineno", None),
-                )
-            repository_paths.append(repository_path)
-        return repository_paths, build_file_paths
-
-    def _git_local_repository_metadata(self, repository_root):
-        git_command = ["git", "-c", "safe.directory={}".format(repository_root), "-C", repository_root]
-        root_result = subprocess.run(
-            git_command + ["rev-parse", "--show-toplevel"],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if root_result.returncode != 0:
-            return None
-        if os.path.realpath(root_result.stdout.strip()) != repository_root:
-            return None
-
-        metadata_paths = []
-        seen_paths = set()
-        commands = [
-            git_command + [
-                "ls-files",
-                "--cached",
-                "--others",
-                "--exclude-standard",
-                "--",
-                *DISCOVERY_GIT_METADATA_PATHS,
-            ],
-            git_command + [
-                "ls-files",
-                "--others",
-                "--ignored",
-                "--exclude-standard",
-                "--",
-                *DISCOVERY_GIT_METADATA_PATHS,
-            ],
-        ]
-        for command in commands:
-            result = subprocess.run(command, check=False, capture_output=True, text=True)
-            if result.returncode != 0:
-                return None
-            for relative_path in result.stdout.splitlines():
-                if not relative_path or relative_path in seen_paths:
-                    continue
-                seen_paths.add(relative_path)
-                metadata_paths.append(os.path.join(repository_root, os.path.normpath(relative_path)))
-                if len(metadata_paths) > DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES:
-                    raise _LocalRepositoryMetadataScanLimit(
-                        repository_root,
-                        "metadata_files",
-                        DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES,
-                    )
-        return metadata_paths
-
-    def _iter_local_repository_metadata(self, repository_root):
-        repository_root = os.path.realpath(repository_root)
-        if not os.path.isdir(repository_root):
-            return []
-
-        git_metadata_paths = self._git_local_repository_metadata(repository_root)
-        if git_metadata_paths is not None:
-            return git_metadata_paths
-
-        pending = [(repository_root, 0)]
-        directories_seen = 0
-        entries_seen = 0
-        metadata_files_seen = 0
-        metadata_paths = []
-        while pending:
-            directory, depth = pending.pop()
-            directories_seen += 1
-            if directories_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_DIRS:
-                raise _LocalRepositoryMetadataScanLimit(
-                    repository_root,
-                    "directories",
-                    DISCOVERY_LOCAL_REPOSITORY_MAX_DIRS,
-                )
-            try:
-                entries = os.scandir(directory)
-            except OSError as exc:
-                raise _LocalRepositoryMetadataScanLimit(
-                    repository_root,
-                    "read_error",
-                    detail="could not read local repository directory {}: {}".format(directory, exc),
-                )
-            with entries:
-                for entry in entries:
-                    try:
-                        if entry.is_symlink():
-                            if entry.name not in ("BUILD", "BUILD.bazel") and not entry.name.endswith(".bzl"):
-                                continue
-                            entries_seen += 1
-                            if entries_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES:
-                                raise _LocalRepositoryMetadataScanLimit(
-                                    repository_root,
-                                    "entries",
-                                    DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES,
-                                )
-                            metadata_files_seen += 1
-                            if metadata_files_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES:
-                                raise _LocalRepositoryMetadataScanLimit(
-                                    repository_root,
-                                    "metadata_files",
-                                    DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES,
-                                )
-                            metadata_paths.append(entry.path)
-                            continue
-                        if entry.is_dir(follow_symlinks=False):
-                            if entry.name in (".git", ".simmer") or entry.name.startswith("bazel-"):
-                                continue
-                            entries_seen += 1
-                            if entries_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES:
-                                raise _LocalRepositoryMetadataScanLimit(
-                                    repository_root,
-                                    "entries",
-                                    DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES,
-                                )
-                            if depth >= DISCOVERY_LOCAL_REPOSITORY_MAX_DEPTH:
-                                raise _LocalRepositoryMetadataScanLimit(
-                                    repository_root,
-                                    "depth",
-                                    DISCOVERY_LOCAL_REPOSITORY_MAX_DEPTH,
-                                )
-                            pending.append((entry.path, depth + 1))
-                            continue
-                        if not entry.is_file(follow_symlinks=False):
-                            continue
-                    except OSError as exc:
-                        raise _LocalRepositoryMetadataScanLimit(
-                            repository_root,
-                            "read_error",
-                            detail="could not inspect local repository entry {}: {}".format(entry.path, exc),
-                        )
-                    entries_seen += 1
-                    if entries_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES:
-                        raise _LocalRepositoryMetadataScanLimit(
-                            repository_root,
-                            "entries",
-                            DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES,
-                        )
-                    if entry.name not in ("BUILD", "BUILD.bazel") and not entry.name.endswith(".bzl"):
-                        continue
-                    metadata_files_seen += 1
-                    if metadata_files_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES:
-                        raise _LocalRepositoryMetadataScanLimit(
-                            repository_root,
-                            "metadata_files",
-                            DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES,
-                        )
-                    metadata_paths.append(entry.path)
-        return metadata_paths
-
     def _iter_project_discovery_dependency_paths(self, submodule_state):
         indexed_result = subprocess.run(
             [
@@ -688,12 +393,7 @@ class RegressionConfig():
                 "--ignored",
                 "--exclude-standard",
                 "--",
-                ":(glob)**/BUILD",
-                ":(glob)**/BUILD.bazel",
-                ":(glob)**/*.bzl",
-                ":(glob)**/*.bazelrc",
-                ":(glob)**/.bazelrc*",
-                *sorted(DISCOVERY_ROOT_FILES),
+                *DISCOVERY_GIT_METADATA_PATHS,
             ],
             cwd=self.proj_dir,
             check=False,
@@ -736,60 +436,11 @@ class RegressionConfig():
         yield from self._bazelrc_dependency_paths()
 
     def _iter_discovery_dependency_paths(self, submodule_state=None):
+        """Yield main-workspace metadata; external IP/VIP changes require bazel clean."""
         if submodule_state is None:
             submodule_state = self._git_submodule_state()
         project_paths = list(self._iter_project_discovery_dependency_paths(submodule_state))
         yield from project_paths
-
-        repository_roots = set()
-        injected_build_files = set()
-        project_root = os.path.realpath(self.proj_dir)
-        for metadata_path in project_paths:
-            metadata_path = os.path.realpath(metadata_path)
-            try:
-                if os.path.commonpath((project_root, metadata_path)) != project_root:
-                    continue
-            except ValueError:
-                continue
-            if not self._is_discovery_dependency(os.path.relpath(metadata_path, project_root)):
-                continue
-            try:
-                repository_paths, build_file_paths = self._local_repository_dependencies(metadata_path)
-            except _UnresolvedLocalRepositoryDeclaration as exc:
-                raise _DiscoveryDependencyScanLimit(
-                    project_paths,
-                    {
-                        "kind": "unresolved_local_repository",
-                        "path": exc.metadata_path,
-                        "line": exc.line,
-                        "detail": exc.detail,
-                    },
-                )
-            injected_build_files.update(build_file_paths)
-            for repository_path in repository_paths:
-                if not os.path.isabs(repository_path):
-                    repository_path = os.path.join(project_root, repository_path)
-                repository_root = os.path.realpath(repository_path)
-                if repository_root != project_root:
-                    repository_roots.add(repository_root)
-        yield from sorted(injected_build_files)
-        for repository_root in sorted(repository_roots):
-            try:
-                metadata_paths = self._iter_local_repository_metadata(repository_root)
-            except _LocalRepositoryMetadataScanLimit as exc:
-                reason = {
-                    "kind": "local_repository_scan_limit",
-                    "path": exc.repository_root,
-                    "limit": exc.limit_name,
-                    "detail": exc.detail,
-                }
-                if exc.maximum is not None:
-                    reason["maximum"] = exc.maximum
-                raise _DiscoveryDependencyScanLimit(
-                    project_paths,
-                    reason,
-                )
-            yield from metadata_paths
 
     def _discovery_cache_is_fresh(self):
         try:

--- a/lib/regression.py
+++ b/lib/regression.py
@@ -46,17 +46,45 @@ DISCOVERY_LOCAL_REPOSITORY_MAX_DIRS = 4096
 DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES = 50000
 DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES = 4096
 DISCOVERY_LOCAL_REPOSITORY_MAX_DECLARATION_BYTES = 4 * 1024 * 1024
+DISCOVERY_GIT_METADATA_PATHS = (
+    "BUILD",
+    "BUILD.bazel",
+    ":(glob)**/BUILD",
+    ":(glob)**/BUILD.bazel",
+    ":(glob)**/*.bzl",
+    ":(glob)**/*.bazelrc",
+    ":(glob)**/.bazelrc*",
+    *sorted(DISCOVERY_ROOT_FILES),
+)
 
 
 class _DiscoveryDependencyScanLimit(Exception):
 
-    def __init__(self, project_paths):
-        super().__init__("local repository metadata scan limit reached")
+    def __init__(self, project_paths, reason):
+        super().__init__(reason.get("detail", "local repository metadata scan failed"))
         self.project_paths = project_paths
+        self.reason = reason
 
 
 class _UnresolvedLocalRepositoryDeclaration(Exception):
-    pass
+
+    def __init__(self, metadata_path, detail, line=None):
+        super().__init__(detail)
+        self.metadata_path = metadata_path
+        self.detail = detail
+        self.line = line
+
+
+class _LocalRepositoryMetadataScanLimit(Exception):
+
+    def __init__(self, repository_root, limit_name, maximum=None, detail=None):
+        if detail is None:
+            detail = "local repository metadata scan exceeded {}={}".format(limit_name, maximum)
+        super().__init__(detail)
+        self.repository_root = repository_root
+        self.limit_name = limit_name
+        self.maximum = maximum
+        self.detail = detail
 
 
 def resolve_report_generation(report_option, total_simulations):
@@ -272,6 +300,7 @@ class RegressionConfig():
         """Publish all discovery payloads as one advisory-locked generation."""
         if manifest is None:
             manifest = self._discovery_dependency_manifest()
+        self._warn_if_discovery_uncacheable(manifest)
         with self._discovery_cache_lock(exclusive=True):
             self.dict_to_json(self.all_vcomp, "all_vcomp.json")
             self.dict_to_json(self.tests_to_tags, "tests_to_tags.json")
@@ -281,32 +310,56 @@ class RegressionConfig():
     def _have_discovery_cache(self):
         return all(os.path.exists(self._cache_path(filename)) for filename in DISCOVERY_CACHE_FILES)
 
+    def _warn_if_discovery_uncacheable(self, manifest):
+        reason = manifest.get("uncacheable_reason")
+        if manifest.get("cacheable", True) or not reason:
+            return
+        if getattr(self, "_discovery_uncacheable_warning_emitted", False):
+            return
+        location = reason.get("path", "unknown path")
+        if reason.get("line") is not None:
+            location = "{}:{}".format(location, reason["line"])
+        self.log.warning("Test discovery cache disabled: %s (%s)", reason.get("detail", reason.get("kind", "unknown")),
+                         location)
+        self._discovery_uncacheable_warning_emitted = True
+
+    @staticmethod
+    def _manifest_relative_path(path, project_root):
+        return os.path.relpath(os.path.realpath(path), project_root).replace(os.sep, "/")
+
     def _discovery_dependency_manifest(self):
         submodule_state = self._git_submodule_state()
+        project_root = os.path.realpath(self.proj_dir)
         cacheable = True
+        uncacheable_reason = None
         try:
             dependency_paths = sorted(set(self._iter_discovery_dependency_paths(submodule_state)))
         except _DiscoveryDependencyScanLimit as exc:
             dependency_paths = sorted(set(exc.project_paths))
             cacheable = False
+            uncacheable_reason = dict(exc.reason)
+            if uncacheable_reason.get("path"):
+                uncacheable_reason["path"] = self._manifest_relative_path(uncacheable_reason["path"], project_root)
         files = []
-        project_root = os.path.realpath(self.proj_dir)
         for path in dependency_paths:
-            relative_path = os.path.relpath(os.path.realpath(path), project_root).replace(os.sep, "/")
+            relative_path = self._manifest_relative_path(path, project_root)
             try:
                 with open(path, "rb") as filep:
                     digest = hashlib.sha256(filep.read()).hexdigest()
             except OSError:
                 digest = "missing"
             files.append({"path": relative_path, "sha256": digest})
-        return {
-            "schema_version": 3,
+        manifest = {
+            "schema_version": 4,
             "cacheable": cacheable,
             "allow_no_run": bool(self.options.allow_no_run),
             "discovery_query": self._build_vcomp_discovery_query(),
             "git_submodules": submodule_state,
             "files": files,
         }
+        if uncacheable_reason is not None:
+            manifest["uncacheable_reason"] = uncacheable_reason
+        return manifest
 
     def _git_submodule_state(self):
         result = subprocess.run(
@@ -357,60 +410,170 @@ class RegressionConfig():
                 continue
 
     def _write_discovery_manifest(self):
+        manifest = self._discovery_dependency_manifest()
+        self._warn_if_discovery_uncacheable(manifest)
         with self._discovery_cache_lock(exclusive=True):
-            self.dict_to_json(self._discovery_dependency_manifest(), "discovery_manifest.json")
+            self.dict_to_json(manifest, "discovery_manifest.json")
 
     @staticmethod
-    def _local_repository_paths(metadata_path):
+    def _ast_expression_name(expression):
+        if isinstance(expression, ast.Name):
+            return expression.id
+        if isinstance(expression, ast.Attribute):
+            return expression.attr
+        return None
+
+    @staticmethod
+    def _literal_string(expression):
+        if isinstance(expression, ast.Constant) and isinstance(expression.value, str):
+            return expression.value
+        return None
+
+    def _repository_build_file_path(self, metadata_path, label, line):
+        if label.startswith("@"):
+            raise _UnresolvedLocalRepositoryDeclaration(
+                metadata_path,
+                "external new_local_repository build_file labels are unsupported",
+                line,
+            )
+        if label.startswith("//"):
+            target = label[2:]
+            if ":" not in target:
+                raise _UnresolvedLocalRepositoryDeclaration(
+                    metadata_path,
+                    "new_local_repository build_file must use an explicit //package:file label",
+                    line,
+                )
+            package, filename = target.split(":", 1)
+            return os.path.join(self.proj_dir, package.replace("/", os.sep), filename)
+        if label.startswith(":"):
+            return os.path.join(os.path.dirname(metadata_path), label[1:])
+        return os.path.join(os.path.dirname(metadata_path), label)
+
+    def _local_repository_dependencies(self, metadata_path):
         try:
             with open(metadata_path, "r", encoding="utf-8", errors="surrogateescape") as filep:
                 source = filep.read(DISCOVERY_LOCAL_REPOSITORY_MAX_DECLARATION_BYTES + 1)
             if len(source) > DISCOVERY_LOCAL_REPOSITORY_MAX_DECLARATION_BYTES:
-                raise _UnresolvedLocalRepositoryDeclaration(metadata_path)
+                raise _UnresolvedLocalRepositoryDeclaration(
+                    metadata_path,
+                    "Bazel metadata file containing local repository declarations exceeds {} bytes".format(
+                        DISCOVERY_LOCAL_REPOSITORY_MAX_DECLARATION_BYTES),
+                )
             tree = ast.parse(source, filename=metadata_path)
         except OSError:
-            return []
-        except (SyntaxError, ValueError):
+            return [], []
+        except (SyntaxError, ValueError) as exc:
             if "local_repository" in source or "new_local_repository" in source:
-                raise _UnresolvedLocalRepositoryDeclaration(metadata_path)
-            return []
+                raise _UnresolvedLocalRepositoryDeclaration(
+                    metadata_path,
+                    "could not parse Bazel metadata containing local repository declarations",
+                    getattr(exc, "lineno", None),
+                )
+            return [], []
 
-        paths = []
+        repository_paths = []
+        build_file_paths = []
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
-            function_name = None
-            if isinstance(node.func, ast.Name):
-                function_name = node.func.id
-            elif isinstance(node.func, ast.Attribute):
-                function_name = node.func.attr
             repository_function_names = {"local_repository", "new_local_repository"}
-            wrapped_function_name = None
-            if node.args:
-                if isinstance(node.args[0], ast.Name):
-                    wrapped_function_name = node.args[0].id
-                elif isinstance(node.args[0], ast.Attribute):
-                    wrapped_function_name = node.args[0].attr
-            direct_declaration = function_name in repository_function_names
-            wrapped_declaration = wrapped_function_name in repository_function_names
-            if not direct_declaration and not wrapped_declaration:
+            rule_name = self._ast_expression_name(node.func)
+            if rule_name not in repository_function_names:
+                repo_rule = None
+                if node.args:
+                    repo_rule = node.args[0]
+                for keyword in node.keywords:
+                    if keyword.arg == "repo_rule":
+                        repo_rule = keyword.value
+                        break
+                rule_name = self._ast_expression_name(repo_rule)
+            if rule_name not in repository_function_names:
                 continue
-            resolved_path = False
-            for keyword in node.keywords:
-                if keyword.arg != "path":
+
+            keywords = {keyword.arg: keyword.value for keyword in node.keywords if keyword.arg is not None}
+            if rule_name == "new_local_repository":
+                if "build_file_content" in keywords:
                     continue
-                if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
-                    paths.append(keyword.value.value)
-                    resolved_path = True
-                break
-            if not resolved_path:
-                raise _UnresolvedLocalRepositoryDeclaration(metadata_path)
-        return paths
+                build_file = self._literal_string(keywords.get("build_file"))
+                if build_file is None:
+                    raise _UnresolvedLocalRepositoryDeclaration(
+                        metadata_path,
+                        "new_local_repository must provide a literal build_file or build_file_content",
+                        getattr(node, "lineno", None),
+                    )
+                build_file_paths.append(
+                    self._repository_build_file_path(metadata_path, build_file, getattr(node, "lineno", None)))
+                continue
+
+            repository_path = self._literal_string(keywords.get("path"))
+            if repository_path is None:
+                raise _UnresolvedLocalRepositoryDeclaration(
+                    metadata_path,
+                    "local_repository path is not a string literal",
+                    getattr(node, "lineno", None),
+                )
+            repository_paths.append(repository_path)
+        return repository_paths, build_file_paths
+
+    def _git_local_repository_metadata(self, repository_root):
+        git_command = ["git", "-c", "safe.directory={}".format(repository_root), "-C", repository_root]
+        root_result = subprocess.run(
+            git_command + ["rev-parse", "--show-toplevel"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if root_result.returncode != 0:
+            return None
+        if os.path.realpath(root_result.stdout.strip()) != repository_root:
+            return None
+
+        metadata_paths = []
+        seen_paths = set()
+        commands = [
+            git_command + [
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+                "--",
+                *DISCOVERY_GIT_METADATA_PATHS,
+            ],
+            git_command + [
+                "ls-files",
+                "--others",
+                "--ignored",
+                "--exclude-standard",
+                "--",
+                *DISCOVERY_GIT_METADATA_PATHS,
+            ],
+        ]
+        for command in commands:
+            result = subprocess.run(command, check=False, capture_output=True, text=True)
+            if result.returncode != 0:
+                return None
+            for relative_path in result.stdout.splitlines():
+                if not relative_path or relative_path in seen_paths:
+                    continue
+                seen_paths.add(relative_path)
+                metadata_paths.append(os.path.join(repository_root, os.path.normpath(relative_path)))
+                if len(metadata_paths) > DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES:
+                    raise _LocalRepositoryMetadataScanLimit(
+                        repository_root,
+                        "metadata_files",
+                        DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES,
+                    )
+        return metadata_paths
 
     def _iter_local_repository_metadata(self, repository_root):
         repository_root = os.path.realpath(repository_root)
         if not os.path.isdir(repository_root):
-            return
+            return []
+
+        git_metadata_paths = self._git_local_repository_metadata(repository_root)
+        if git_metadata_paths is not None:
+            return git_metadata_paths
 
         pending = [(repository_root, 0)]
         directories_seen = 0
@@ -421,11 +584,19 @@ class RegressionConfig():
             directory, depth = pending.pop()
             directories_seen += 1
             if directories_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_DIRS:
-                return None
+                raise _LocalRepositoryMetadataScanLimit(
+                    repository_root,
+                    "directories",
+                    DISCOVERY_LOCAL_REPOSITORY_MAX_DIRS,
+                )
             try:
                 entries = os.scandir(directory)
-            except OSError:
-                return None
+            except OSError as exc:
+                raise _LocalRepositoryMetadataScanLimit(
+                    repository_root,
+                    "read_error",
+                    detail="could not read local repository directory {}: {}".format(directory, exc),
+                )
             with entries:
                 for entry in entries:
                     try:
@@ -434,10 +605,18 @@ class RegressionConfig():
                                 continue
                             entries_seen += 1
                             if entries_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES:
-                                return None
+                                raise _LocalRepositoryMetadataScanLimit(
+                                    repository_root,
+                                    "entries",
+                                    DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES,
+                                )
                             metadata_files_seen += 1
                             if metadata_files_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES:
-                                return None
+                                raise _LocalRepositoryMetadataScanLimit(
+                                    repository_root,
+                                    "metadata_files",
+                                    DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES,
+                                )
                             metadata_paths.append(entry.path)
                             continue
                         if entry.is_dir(follow_symlinks=False):
@@ -445,23 +624,43 @@ class RegressionConfig():
                                 continue
                             entries_seen += 1
                             if entries_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES:
-                                return None
+                                raise _LocalRepositoryMetadataScanLimit(
+                                    repository_root,
+                                    "entries",
+                                    DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES,
+                                )
                             if depth >= DISCOVERY_LOCAL_REPOSITORY_MAX_DEPTH:
-                                return None
+                                raise _LocalRepositoryMetadataScanLimit(
+                                    repository_root,
+                                    "depth",
+                                    DISCOVERY_LOCAL_REPOSITORY_MAX_DEPTH,
+                                )
                             pending.append((entry.path, depth + 1))
                             continue
                         if not entry.is_file(follow_symlinks=False):
                             continue
-                    except OSError:
-                        return None
+                    except OSError as exc:
+                        raise _LocalRepositoryMetadataScanLimit(
+                            repository_root,
+                            "read_error",
+                            detail="could not inspect local repository entry {}: {}".format(entry.path, exc),
+                        )
                     entries_seen += 1
                     if entries_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES:
-                        return None
+                        raise _LocalRepositoryMetadataScanLimit(
+                            repository_root,
+                            "entries",
+                            DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES,
+                        )
                     if entry.name not in ("BUILD", "BUILD.bazel") and not entry.name.endswith(".bzl"):
                         continue
                     metadata_files_seen += 1
                     if metadata_files_seen > DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES:
-                        return None
+                        raise _LocalRepositoryMetadataScanLimit(
+                            repository_root,
+                            "metadata_files",
+                            DISCOVERY_LOCAL_REPOSITORY_MAX_METADATA_FILES,
+                        )
                     metadata_paths.append(entry.path)
         return metadata_paths
 
@@ -535,6 +734,7 @@ class RegressionConfig():
         yield from project_paths
 
         repository_roots = set()
+        injected_build_files = set()
         project_root = os.path.realpath(self.proj_dir)
         for metadata_path in project_paths:
             metadata_path = os.path.realpath(metadata_path)
@@ -546,19 +746,41 @@ class RegressionConfig():
             if not self._is_discovery_dependency(os.path.relpath(metadata_path, project_root)):
                 continue
             try:
-                repository_paths = self._local_repository_paths(metadata_path)
-            except _UnresolvedLocalRepositoryDeclaration:
-                raise _DiscoveryDependencyScanLimit(project_paths)
+                repository_paths, build_file_paths = self._local_repository_dependencies(metadata_path)
+            except _UnresolvedLocalRepositoryDeclaration as exc:
+                raise _DiscoveryDependencyScanLimit(
+                    project_paths,
+                    {
+                        "kind": "unresolved_local_repository",
+                        "path": exc.metadata_path,
+                        "line": exc.line,
+                        "detail": exc.detail,
+                    },
+                )
+            injected_build_files.update(build_file_paths)
             for repository_path in repository_paths:
                 if not os.path.isabs(repository_path):
                     repository_path = os.path.join(project_root, repository_path)
                 repository_root = os.path.realpath(repository_path)
                 if repository_root != project_root:
                     repository_roots.add(repository_root)
+        yield from sorted(injected_build_files)
         for repository_root in sorted(repository_roots):
-            metadata_paths = self._iter_local_repository_metadata(repository_root)
-            if metadata_paths is None:
-                raise _DiscoveryDependencyScanLimit(project_paths)
+            try:
+                metadata_paths = self._iter_local_repository_metadata(repository_root)
+            except _LocalRepositoryMetadataScanLimit as exc:
+                reason = {
+                    "kind": "local_repository_scan_limit",
+                    "path": exc.repository_root,
+                    "limit": exc.limit_name,
+                    "detail": exc.detail,
+                }
+                if exc.maximum is not None:
+                    reason["maximum"] = exc.maximum
+                raise _DiscoveryDependencyScanLimit(
+                    project_paths,
+                    reason,
+                )
             yield from metadata_paths
 
     def _discovery_cache_is_fresh(self):
@@ -568,6 +790,7 @@ class RegressionConfig():
                     return False
                 _, _, _, cached_manifest = self._read_discovery_cache_locked()
                 if not cached_manifest.get("cacheable", True):
+                    self._warn_if_discovery_uncacheable(cached_manifest)
                     return False
                 current_manifest = self._discovery_dependency_manifest()
         except (OSError, ValueError, json.JSONDecodeError):
@@ -584,6 +807,7 @@ class RegressionConfig():
                     return False
                 all_vcomp, tests_to_tags, tests_to_simulator, cached_manifest = self._read_discovery_cache_locked()
                 if not cached_manifest.get("cacheable", True):
+                    self._warn_if_discovery_uncacheable(cached_manifest)
                     return False
                 if cached_manifest != self._discovery_dependency_manifest():
                     self.log.debug("Discovery cache dependency manifest changed")

--- a/lib/regression.py
+++ b/lib/regression.py
@@ -666,7 +666,15 @@ class RegressionConfig():
 
     def _iter_project_discovery_dependency_paths(self, submodule_state):
         indexed_result = subprocess.run(
-            ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+            [
+                "git",
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+                "--",
+                *DISCOVERY_GIT_METADATA_PATHS,
+            ],
             cwd=self.proj_dir,
             check=False,
             capture_output=True,

--- a/tests/args_parser_validation_test.py
+++ b/tests/args_parser_validation_test.py
@@ -23,6 +23,10 @@ class ArgsParserValidationTest(unittest.TestCase):
         self.assertEqual(99999999, options.wave_end)
         self.assertFalse(options.wave_end_was_explicit)
 
+    def test_default_wave_depth_is_bounded(self):
+        self.assertEqual(10, parse_args(["--waves"]).wave_depth)
+        self.assertEqual(999, parse_args(["--waves", "--wave-depth", "999"]).wave_depth)
+
     def test_explicit_wave_end_must_follow_wave_start(self):
         self.assert_parse_error(["--waves", "--wave-start", "20", "--wave-end", "10"])
         self.assert_parse_error(["--waves", "--wave-start", "100000000", "--wave-end", "99999999"])

--- a/tests/bazel_profile_test.py
+++ b/tests/bazel_profile_test.py
@@ -94,6 +94,47 @@ class BazelProfileTest(unittest.TestCase):
         finally:
             os.remove(profile_path)
 
+    def test_repository_timings_merge_overlapping_events_and_ignore_generic_function_name(self):
+        profile = {
+            "traceEvents": [
+                {
+                    "ph": "X",
+                    "cat": "repository",
+                    "name": "Repository rule @rules_python",
+                    "ts": 1_000_000,
+                    "dur": 4_000_000
+                },
+                {
+                    "ph": "X",
+                    "cat": "repository",
+                    "name": "fetch",
+                    "ts": 2_000_000,
+                    "dur": 2_000_000,
+                    "args": {
+                        "repository": "rules_python"
+                    }
+                },
+                {
+                    "ph": "X",
+                    "cat": "repository",
+                    "name": "Starlark repository function",
+                    "ts": 0,
+                    "dur": 20_000_000
+                },
+            ],
+        }
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as profile_file:
+            json.dump(profile, profile_file)
+            profile_path = profile_file.name
+
+        try:
+            self.assertEqual(
+                [(4.0, "rules_python", 2)],
+                bazel_profile.repository_timings(profile_path),
+            )
+        finally:
+            os.remove(profile_path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/bazel_profile_test.py
+++ b/tests/bazel_profile_test.py
@@ -8,6 +8,42 @@ from lib import bazel_profile
 
 class BazelProfileTest(unittest.TestCase):
 
+    def test_phase_timings_measure_intervals_between_build_phase_markers(self):
+        profile = {
+            "traceEvents": [
+                {
+                    "ph": "i",
+                    "cat": "build phase marker",
+                    "name": "Launch Blaze",
+                    "ts": 1_000_000
+                },
+                {
+                    "ph": "i",
+                    "cat": "build phase marker",
+                    "name": "Analyze",
+                    "ts": 3_500_000
+                },
+                {
+                    "ph": "X",
+                    "cat": "action",
+                    "name": "compile",
+                    "ts": 4_000_000,
+                    "dur": 1_000_000
+                },
+            ],
+        }
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as profile_file:
+            json.dump(profile, profile_file)
+            profile_path = profile_file.name
+
+        try:
+            self.assertEqual(
+                [(2.5, "Launch Blaze"), (1.5, "Analyze")],
+                bazel_profile.phase_timings(profile_path),
+            )
+        finally:
+            os.remove(profile_path)
+
     def test_repository_timings_aggregate_real_repository_events(self):
         profile = {
             "traceEvents": [

--- a/tests/job_manager_launch_test.py
+++ b/tests/job_manager_launch_test.py
@@ -301,6 +301,42 @@ class JobManagerLaunchTest(unittest.TestCase):
 
         self.assertEqual("bazel build //pkg/tests:second", job.main_cmdline)
 
+    def test_cached_discovery_reuses_existing_tb_and_test_cfg_outputs(self):
+        project_dir = tempfile.mkdtemp()
+        os.makedirs(os.path.join(project_dir, "bazel-bin", "pkg", "tb.runfiles", "__main__"))
+        tests_dir = os.path.join(project_dir, "bazel-bin", "pkg", "tests")
+        os.makedirs(tests_dir)
+        Path(tests_dir, "first_dynamic_args.py").touch()
+        log = _Logger()
+        rcfg = SimpleNamespace(
+            options=SimpleNamespace(timeout=1, no_compile=False, no_bazel=False),
+            log=log,
+            proj_dir=project_dir,
+            use_cached_discovery=True,
+        )
+        vcomper = SimpleNamespace(job_dir="vcomp_dir", add_dependency=lambda _job: None)
+
+        job = BazelTBJob(rcfg, "//pkg:tb", vcomper, additional_targets=["//pkg/tests:first"])
+
+        self.assertNotIn("bazel build", job.main_cmdline)
+        self.assertIn("cached or discovery-built", job.main_cmdline)
+
+    def test_cached_discovery_rebuilds_outputs_missing_after_bazel_clean(self):
+        project_dir = tempfile.mkdtemp()
+        os.makedirs(os.path.join(project_dir, "bazel-bin", "pkg", "tb.runfiles", "__main__"))
+        log = _Logger()
+        rcfg = SimpleNamespace(
+            options=SimpleNamespace(timeout=1, no_compile=False, no_bazel=False),
+            log=log,
+            proj_dir=project_dir,
+            use_cached_discovery=True,
+        )
+        vcomper = SimpleNamespace(job_dir="vcomp_dir", add_dependency=lambda _job: None)
+
+        job = BazelTBJob(rcfg, "//pkg:tb", vcomper, additional_targets=["//pkg/tests:first"])
+
+        self.assertEqual("bazel build //pkg/tests:first", job.main_cmdline)
+
     def test_no_compile_still_builds_test_configs(self):
         log = _Logger()
         rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1, no_compile=True, no_bazel=False), log=log)

--- a/tests/job_manager_launch_test.py
+++ b/tests/job_manager_launch_test.py
@@ -263,6 +263,29 @@ class JobManagerLaunchTest(unittest.TestCase):
 
         self.assertEqual("bazel build //pkg:tb //pkg/tests:first //pkg/tests:second", job.main_cmdline)
 
+    def test_bazel_tb_job_records_bazel_profile_when_simmer_profile_is_enabled(self):
+        profile_dir = tempfile.mkdtemp()
+        log = _Logger()
+        rcfg = SimpleNamespace(
+            options=SimpleNamespace(timeout=1, no_compile=False, no_bazel=False, simmer_profile=True),
+            log=log,
+            profile_events=[],
+        )
+        vcomper = SimpleNamespace(job_dir=profile_dir, add_dependency=lambda _job: None)
+        job = BazelTBJob(rcfg, "//pkg:tb", vcomper)
+
+        self.assertIn("--profile=", job.main_cmdline)
+        self.assertIn("bazel_tb_profile.json", job.main_cmdline)
+
+        with open(job.bazel_profile_path, "w", encoding="utf-8") as profile_file:
+            profile_file.write('{"traceEvents": [{"ph": "i", "cat": "build phase marker", '
+                               '"name": "Analyze", "ts": 0}, '
+                               '{"ph": "X", "cat": "action", "name": "compile", "ts": 0, "dur": 2000000}]}')
+        job._collect_bazel_profile()
+
+        self.assertIn((2.0, "bazel_build_phase: Analyze", "//pkg:tb"), rcfg.profile_events)
+        self.assertIn((0.0, "bazel_build_profile", job.bazel_profile_path), rcfg.profile_events)
+
     def test_bazel_tb_job_skips_targets_built_during_discovery(self):
         log = _Logger()
         rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1, no_compile=False, no_bazel=False), log=log)

--- a/tests/regression_discovery_test.py
+++ b/tests/regression_discovery_test.py
@@ -254,7 +254,7 @@ class RegressionDiscoveryTest(unittest.TestCase):
 
         self.assertFalse(config._discovery_cache_is_fresh())
 
-    def test_cache_manifest_tracks_wrapped_new_local_repository_declared_in_bzl(self):
+    def test_cache_manifest_tracks_injected_new_local_repository_build_file(self):
         project_dir = Path(tempfile.mkdtemp())
         repository_dir = Path(tempfile.mkdtemp())
         subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
@@ -263,10 +263,13 @@ class RegressionDiscoveryTest(unittest.TestCase):
         repos_bzl.parent.mkdir()
         repos_bzl.write_text(
             "def declare_repositories():\n"
-            "    maybe(native.new_local_repository, name = 'mutable_ip', path = {!r}, build_file = '//:BUILD')\n".
-            format(str(repository_dir)),
+            "    maybe(repo_rule = native.new_local_repository, name = 'mutable_ip', "
+            "path = ROOT.format('ip'), build_file = '//vendor:BUILD.mutable_ip')\n",
             encoding="utf-8",
         )
+        injected_build = project_dir / "vendor" / "BUILD.mutable_ip"
+        injected_build.parent.mkdir()
+        injected_build.write_text("filegroup(name = 'first')\n", encoding="utf-8")
         repository_bzl = repository_dir / "defs.bzl"
         repository_bzl.write_text("VALUE = 'first'\n", encoding="utf-8")
         config = self._config(project_dir)
@@ -278,8 +281,79 @@ class RegressionDiscoveryTest(unittest.TestCase):
         config._write_discovery_manifest()
         self.assertTrue(config._discovery_cache_is_fresh())
         repository_bzl.write_text("VALUE = 'second'\n", encoding="utf-8")
+        self.assertTrue(config._discovery_cache_is_fresh())
+        injected_build.write_text("filegroup(name = 'second')\n", encoding="utf-8")
 
         self.assertFalse(config._discovery_cache_is_fresh())
+
+    def test_new_local_repository_build_file_content_does_not_require_literal_source_path(self):
+        project_dir = Path(tempfile.mkdtemp())
+        subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
+        (project_dir / "WORKSPACE").write_text(
+            "PDK_ROOT = '/large/vendor/tree'\n"
+            "new_local_repository(\n"
+            "    name = 'pdk',\n"
+            "    path = PDK_ROOT,\n"
+            "    build_file_content = \"filegroup(name = 'all')\",\n"
+            ")\n",
+            encoding="utf-8",
+        )
+        config = self._config(project_dir)
+
+        manifest = config._discovery_dependency_manifest()
+
+        self.assertTrue(manifest["cacheable"])
+        self.assertNotIn("uncacheable_reason", manifest)
+
+    def test_cache_manifest_tracks_keyword_wrapped_git_local_repository_metadata(self):
+        project_dir = Path(tempfile.mkdtemp())
+        repository_dir = Path(tempfile.mkdtemp())
+        subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
+        subprocess.run(["git", "init", "-q"], cwd=repository_dir, check=True)
+        (project_dir / "WORKSPACE").write_text(
+            "maybe(name = 'mutable_ip', repo_rule = native.local_repository, path = {!r})\n".format(
+                str(repository_dir)),
+            encoding="utf-8",
+        )
+        repository_bzl = repository_dir / "defs.bzl"
+        repository_bzl.write_text("VALUE = 'first'\n", encoding="utf-8")
+        source_file = repository_dir / "large_source.sv"
+        source_file.write_text("module first; endmodule\n", encoding="utf-8")
+        config = self._config(project_dir)
+        cache_dir = project_dir / ".simmer" / "cache"
+        cache_dir.mkdir(parents=True)
+        for filename in ("all_vcomp.json", "tests_to_tags.json", "tests_to_simulator.json"):
+            (cache_dir / filename).write_text("{}", encoding="utf-8")
+
+        config._write_discovery_manifest()
+        manifest = json.loads((cache_dir / "discovery_manifest.json").read_text(encoding="utf-8"))
+        manifest_paths = {entry["path"] for entry in manifest["files"]}
+        repository_bzl_path = os.path.relpath(os.path.realpath(repository_bzl),
+                                              os.path.realpath(project_dir)).replace(os.sep, "/")
+        source_path = os.path.relpath(os.path.realpath(source_file), os.path.realpath(project_dir)).replace(os.sep, "/")
+        self.assertIn(repository_bzl_path, manifest_paths)
+        self.assertNotIn(source_path, manifest_paths)
+        self.assertTrue(manifest["cacheable"])
+
+        repository_bzl.write_text("VALUE = 'second'\n", encoding="utf-8")
+
+        self.assertFalse(config._discovery_cache_is_fresh())
+
+    def test_git_local_repository_metadata_does_not_walk_source_tree(self):
+        repository_dir = Path(tempfile.mkdtemp())
+        subprocess.run(["git", "init", "-q"], cwd=repository_dir, check=True)
+        (repository_dir / "BUILD").write_text("filegroup(name = 'metadata')\n", encoding="utf-8")
+        for index in range(100):
+            (repository_dir / "source_{:03d}.sv".format(index)).write_text(
+                "module source_{:03d}; endmodule\n".format(index),
+                encoding="utf-8",
+            )
+        config = self._config(Path(tempfile.mkdtemp()))
+
+        with mock.patch("lib.regression.os.scandir", side_effect=AssertionError("source tree walk should not run")):
+            metadata_paths = config._iter_local_repository_metadata(repository_dir)
+
+        self.assertEqual([str(repository_dir / "BUILD")], metadata_paths)
 
     def test_local_repository_scan_follows_safe_metadata_symlink(self):
         project_dir = Path(tempfile.mkdtemp())
@@ -309,7 +383,7 @@ class RegressionDiscoveryTest(unittest.TestCase):
         self.assertIn(os.path.realpath(linked_build), [os.path.realpath(path) for path in metadata_paths])
         self.assertFalse(config._discovery_cache_is_fresh())
 
-    def test_local_repository_scan_limit_disables_cache_reuse_without_warning(self):
+    def test_local_repository_scan_limit_records_reason_and_warns(self):
         project_dir = Path(tempfile.mkdtemp())
         repository_dir = Path(tempfile.mkdtemp())
         subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
@@ -330,9 +404,11 @@ class RegressionDiscoveryTest(unittest.TestCase):
             config._write_discovery_manifest()
             manifest = json.loads((cache_dir / "discovery_manifest.json").read_text(encoding="utf-8"))
             self.assertFalse(manifest["cacheable"])
+            self.assertEqual("local_repository_scan_limit", manifest["uncacheable_reason"]["kind"])
+            self.assertEqual("entries", manifest["uncacheable_reason"]["limit"])
             self.assertFalse(config._discovery_cache_is_fresh())
 
-        config.log.warning.assert_not_called()
+        config.log.warning.assert_called_once()
 
     def test_oversized_local_repository_declaration_disables_cache_reuse(self):
         project_dir = Path(tempfile.mkdtemp())
@@ -347,6 +423,8 @@ class RegressionDiscoveryTest(unittest.TestCase):
             manifest = config._discovery_dependency_manifest()
 
         self.assertFalse(manifest["cacheable"])
+        self.assertEqual("unresolved_local_repository", manifest["uncacheable_reason"]["kind"])
+        self.assertEqual("WORKSPACE", manifest["uncacheable_reason"]["path"])
 
     def test_nonliteral_direct_local_repository_path_disables_cache_reuse(self):
         project_dir = Path(tempfile.mkdtemp())
@@ -361,6 +439,8 @@ class RegressionDiscoveryTest(unittest.TestCase):
         manifest = config._discovery_dependency_manifest()
 
         self.assertFalse(manifest["cacheable"])
+        self.assertEqual("unresolved_local_repository", manifest["uncacheable_reason"]["kind"])
+        self.assertEqual(2, manifest["uncacheable_reason"]["line"])
 
     def test_no_bazel_rejects_stale_cache(self):
         config = self._config(Path(tempfile.mkdtemp()))

--- a/tests/regression_discovery_test.py
+++ b/tests/regression_discovery_test.py
@@ -184,7 +184,7 @@ class RegressionDiscoveryTest(unittest.TestCase):
         self.assertEqual(3, run.call_count)
         indexed_command = run.call_args_list[1].args[0]
         self.assertIn("--", indexed_command)
-        self.assertIn(":(glob)**/BUILD", indexed_command)
+        self.assertIn(":(glob)**/BUILD*", indexed_command)
         self.assertIn(":(glob)**/*.bzl", indexed_command)
 
     def test_cache_manifest_tracks_imported_bazelrc(self):
@@ -224,7 +224,7 @@ class RegressionDiscoveryTest(unittest.TestCase):
 
         self.assertFalse(config._discovery_cache_is_fresh())
 
-    def test_cache_manifest_tracks_local_repository_bazel_metadata_only(self):
+    def test_cache_manifest_ignores_local_repository_changes(self):
         project_dir = Path(tempfile.mkdtemp())
         repository_dir = Path(tempfile.mkdtemp())
         subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
@@ -250,13 +250,13 @@ class RegressionDiscoveryTest(unittest.TestCase):
         build_relative_path = os.path.relpath(os.path.realpath(build_file), canonical_project_dir).replace(os.sep, "/")
         source_relative_path = os.path.relpath(os.path.realpath(source_file),
                                                canonical_project_dir).replace(os.sep, "/")
-        self.assertIn(build_relative_path, manifest_paths)
+        self.assertNotIn(build_relative_path, manifest_paths)
         self.assertNotIn(source_relative_path, manifest_paths)
         self.assertTrue(config._discovery_cache_is_fresh())
 
         build_file.write_text("filegroup(name = 'second')\n", encoding="utf-8")
 
-        self.assertFalse(config._discovery_cache_is_fresh())
+        self.assertTrue(config._discovery_cache_is_fresh())
 
     def test_cache_manifest_tracks_injected_new_local_repository_build_file(self):
         project_dir = Path(tempfile.mkdtemp())
@@ -309,7 +309,7 @@ class RegressionDiscoveryTest(unittest.TestCase):
         self.assertTrue(manifest["cacheable"])
         self.assertNotIn("uncacheable_reason", manifest)
 
-    def test_cache_manifest_tracks_keyword_wrapped_git_local_repository_metadata(self):
+    def test_cache_manifest_ignores_keyword_wrapped_local_repository_changes(self):
         project_dir = Path(tempfile.mkdtemp())
         repository_dir = Path(tempfile.mkdtemp())
         subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
@@ -335,31 +335,15 @@ class RegressionDiscoveryTest(unittest.TestCase):
         repository_bzl_path = os.path.relpath(os.path.realpath(repository_bzl),
                                               os.path.realpath(project_dir)).replace(os.sep, "/")
         source_path = os.path.relpath(os.path.realpath(source_file), os.path.realpath(project_dir)).replace(os.sep, "/")
-        self.assertIn(repository_bzl_path, manifest_paths)
+        self.assertNotIn(repository_bzl_path, manifest_paths)
         self.assertNotIn(source_path, manifest_paths)
         self.assertTrue(manifest["cacheable"])
 
         repository_bzl.write_text("VALUE = 'second'\n", encoding="utf-8")
 
-        self.assertFalse(config._discovery_cache_is_fresh())
+        self.assertTrue(config._discovery_cache_is_fresh())
 
-    def test_git_local_repository_metadata_does_not_walk_source_tree(self):
-        repository_dir = Path(tempfile.mkdtemp())
-        subprocess.run(["git", "init", "-q"], cwd=repository_dir, check=True)
-        (repository_dir / "BUILD").write_text("filegroup(name = 'metadata')\n", encoding="utf-8")
-        for index in range(100):
-            (repository_dir / "source_{:03d}.sv".format(index)).write_text(
-                "module source_{:03d}; endmodule\n".format(index),
-                encoding="utf-8",
-            )
-        config = self._config(Path(tempfile.mkdtemp()))
-
-        with mock.patch("lib.regression.os.scandir", side_effect=AssertionError("source tree walk should not run")):
-            metadata_paths = config._iter_local_repository_metadata(repository_dir)
-
-        self.assertEqual([str(repository_dir / "BUILD")], metadata_paths)
-
-    def test_local_repository_scan_follows_safe_metadata_symlink(self):
+    def test_external_local_repository_symlink_does_not_invalidate_workspace_cache(self):
         project_dir = Path(tempfile.mkdtemp())
         repository_dir = Path(tempfile.mkdtemp())
         subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
@@ -380,14 +364,12 @@ class RegressionDiscoveryTest(unittest.TestCase):
         for filename in ("all_vcomp.json", "tests_to_tags.json", "tests_to_simulator.json"):
             (cache_dir / filename).write_text("{}", encoding="utf-8")
 
-        metadata_paths = config._iter_local_repository_metadata(repository_dir)
         config._write_discovery_manifest()
         real_build.write_text("filegroup(name = 'second')\n", encoding="utf-8")
 
-        self.assertIn(os.path.realpath(linked_build), [os.path.realpath(path) for path in metadata_paths])
-        self.assertFalse(config._discovery_cache_is_fresh())
+        self.assertTrue(config._discovery_cache_is_fresh())
 
-    def test_local_repository_scan_limit_records_reason_and_warns(self):
+    def test_large_local_repository_does_not_disable_workspace_cache(self):
         project_dir = Path(tempfile.mkdtemp())
         repository_dir = Path(tempfile.mkdtemp())
         subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
@@ -404,17 +386,15 @@ class RegressionDiscoveryTest(unittest.TestCase):
         for filename in ("all_vcomp.json", "tests_to_tags.json", "tests_to_simulator.json"):
             (cache_dir / filename).write_text("{}", encoding="utf-8")
 
-        with mock.patch("lib.regression.DISCOVERY_LOCAL_REPOSITORY_MAX_ENTRIES", 1):
-            config._write_discovery_manifest()
-            manifest = json.loads((cache_dir / "discovery_manifest.json").read_text(encoding="utf-8"))
-            self.assertFalse(manifest["cacheable"])
-            self.assertEqual("local_repository_scan_limit", manifest["uncacheable_reason"]["kind"])
-            self.assertEqual("entries", manifest["uncacheable_reason"]["limit"])
-            self.assertFalse(config._discovery_cache_is_fresh())
+        config._write_discovery_manifest()
+        manifest = json.loads((cache_dir / "discovery_manifest.json").read_text(encoding="utf-8"))
+        self.assertTrue(manifest["cacheable"])
+        self.assertNotIn("uncacheable_reason", manifest)
+        self.assertTrue(config._discovery_cache_is_fresh())
 
-        config.log.warning.assert_called_once()
+        config.log.warning.assert_not_called()
 
-    def test_oversized_local_repository_declaration_disables_cache_reuse(self):
+    def test_oversized_local_repository_declaration_does_not_disable_cache_reuse(self):
         project_dir = Path(tempfile.mkdtemp())
         subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
         (project_dir / "WORKSPACE").write_text(
@@ -423,14 +403,12 @@ class RegressionDiscoveryTest(unittest.TestCase):
         )
         config = self._config(project_dir)
 
-        with mock.patch("lib.regression.DISCOVERY_LOCAL_REPOSITORY_MAX_DECLARATION_BYTES", 8):
-            manifest = config._discovery_dependency_manifest()
+        manifest = config._discovery_dependency_manifest()
 
-        self.assertFalse(manifest["cacheable"])
-        self.assertEqual("unresolved_local_repository", manifest["uncacheable_reason"]["kind"])
-        self.assertEqual("WORKSPACE", manifest["uncacheable_reason"]["path"])
+        self.assertTrue(manifest["cacheable"])
+        self.assertNotIn("uncacheable_reason", manifest)
 
-    def test_nonliteral_direct_local_repository_path_disables_cache_reuse(self):
+    def test_nonliteral_direct_local_repository_path_does_not_disable_cache_reuse(self):
         project_dir = Path(tempfile.mkdtemp())
         subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True)
         (project_dir / "WORKSPACE").write_text(
@@ -442,9 +420,8 @@ class RegressionDiscoveryTest(unittest.TestCase):
 
         manifest = config._discovery_dependency_manifest()
 
-        self.assertFalse(manifest["cacheable"])
-        self.assertEqual("unresolved_local_repository", manifest["uncacheable_reason"]["kind"])
-        self.assertEqual(2, manifest["uncacheable_reason"]["line"])
+        self.assertTrue(manifest["cacheable"])
+        self.assertNotIn("uncacheable_reason", manifest)
 
     def test_no_bazel_rejects_stale_cache(self):
         config = self._config(Path(tempfile.mkdtemp()))

--- a/tests/regression_discovery_test.py
+++ b/tests/regression_discovery_test.py
@@ -182,6 +182,10 @@ class RegressionDiscoveryTest(unittest.TestCase):
         ):
             self.assertIn(str(expected), dependencies)
         self.assertEqual(3, run.call_count)
+        indexed_command = run.call_args_list[1].args[0]
+        self.assertIn("--", indexed_command)
+        self.assertIn(":(glob)**/BUILD", indexed_command)
+        self.assertIn(":(glob)**/*.bzl", indexed_command)
 
     def test_cache_manifest_tracks_imported_bazelrc(self):
         proj_dir = Path(tempfile.mkdtemp())

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -1544,7 +1544,7 @@ run_bounded_process([
         self.assertIn("run 80ns", rendered)
         self.assertIn("database -close shm_db", rendered)
 
-    def test_vcs_wave_template_uses_returned_fsdb_id_and_unlimited_default_depth(self):
+    def test_vcs_wave_template_uses_returned_fsdb_id_and_explicit_unlimited_depth(self):
         wave_template = self._read_repo_file("bin/templates/vcs_wave_cmd_template.tcl.j2")
         environment = jinja2.Environment(undefined=jinja2.StrictUndefined)
         environment.filters["tcl_quote"] = _vcs_tcl_quote


### PR DESCRIPTION
## Summary
- speed up cached simmer test discovery by validating only Bazel metadata in the main workspace; changes in external IP/VIP repositories are picked up after an explicit `bazel clean`
- reuse discovery-built or cached testbench/test-config Bazel outputs, while rebuilding automatically when `bazel clean` removes them
- improve scheduled Bazel profiling and repository timing attribution
- limit the default VCS waveform hierarchy depth to 10 while retaining interface visibility and source-code debug

## Validation
- discovery cache tests: 24 passed, 1 Windows POSIX-lock skip
- Bazel job tests: 8 passed
- docs tests: 5 passed
- parser tests: 5 passed
- focused VCS wave tests passed
- YAPF, Python compile, and diff checks passed

## SHICloud/VCS evidence
- unchanged cached run: discovery cache check 6.35s, BazelTBJob 0.40s, VComp cache hit 1.30s
- cache validation improved from roughly 35–48s to roughly 5–6s
- after `bazel clean`, discovery/build outputs are regenerated as expected