### PR TITLE
Discover test configs created by wrapper macros

### DIFF
--- a/lib/regression.py
+++ b/lib/regression.py
@@ -519,13 +519,15 @@ class RegressionConfig():
     def _build_test_cfg_query(self, vcomp):
         vcomp_path, _ = vcomp.split(':')
         test_wildcard = os.path.join(vcomp_path, "tests", "...")
-        generated_test_cfgs = 'attr(generator_function, verilog_dv_test_cfg, {test_wildcard} intersect allpaths({test_wildcard}, {vcomp}))'.format(
+        # generator_function names the outermost macro, while this rule marker
+        # survives consumer wrappers around verilog_dv_test_cfg.
+        test_cfgs = 'attr(verilog_dv_test_cfg_marker, 1, {test_wildcard} intersect allpaths({test_wildcard}, {vcomp}))'.format(
             test_wildcard=test_wildcard,
             vcomp=vcomp,
         )
         if self.options.allow_no_run:
-            return 'attr(abstract, 0, {})'.format(generated_test_cfgs)
-        return 'attr(no_run, 0, attr(abstract, 0, {}))'.format(generated_test_cfgs)
+            return 'attr(abstract, 0, {})'.format(test_cfgs)
+        return 'attr(no_run, 0, attr(abstract, 0, {}))'.format(test_cfgs)
 
     def _run_command(self, cmd):
         command = list(cmd)

--- a/tests/regression_discovery_test.py
+++ b/tests/regression_discovery_test.py
@@ -453,14 +453,13 @@ class RegressionDiscoveryTest(unittest.TestCase):
 
         self.assertNotEqual(initial, config._discovery_dependency_manifest())
 
-    def test_test_cfg_query_uses_the_public_macro_identity(self):
+    def test_test_cfg_query_uses_rule_marker_for_wrapped_macros(self):
         config = self._config(Path(tempfile.mkdtemp()))
 
         query = config._build_test_cfg_query("//benches/soc_tb:soc_tb")
 
-        self.assertIn("attr(generator_function, verilog_dv_test_cfg,", query)
-        self.assertNotIn("dv_test_cfg_rule", query)
-        self.assertNotIn("base_cfg", query)
+        self.assertIn("attr(verilog_dv_test_cfg_marker, 1,", query)
+        self.assertNotIn("generator_function", query)
 
     def test_discovery_batches_cquery_and_build(self):
         proj_dir = Path(tempfile.mkdtemp())

--- a/verilog/private/dv.bzl
+++ b/verilog/private/dv.bzl
@@ -241,6 +241,10 @@ _verilog_dv_test_cfg_rule = rule(
                   "Unlike other inheritable attributes, values in sim_opts are not entirely overridden. Instead, the dictionary is 'updated' with new values at each successive level.\n" +
                   "This allows for the override of individual simopts for finer-grained control.",
         ),
+        "verilog_dv_test_cfg_marker": attr.bool(
+            default = True,
+            doc = "Internal marker used by simmer discovery. Public macros do not expose this attribute.",
+        ),
         "no_run": attr.bool(
             default = False,
             doc = "Set to True to skip running this test.\n" +


### PR DESCRIPTION
## Summary

- discover `verilog_dv_test_cfg` targets created through consumer wrapper macros
- replace the unstable `generator_function` filter with a rule-owned discovery marker
- retain the existing abstract and `no_run` filtering behavior

## Root cause

Bazel records the outermost consumer macro in `generator_function`. A valid test config created by a wrapper such as `spi_test_configs()` therefore exists in `bazel query` but was silently excluded from simmer discovery.

## Validation

- `py -3 -m unittest tests.regression_discovery_test` (24 passed, 1 Windows/POSIX skip)
- `py -3 tests/docs_test.py` (5 passed)
- Python syntax compilation
- YAPF 0.43.0 diff check
- `git diff --check`
- XinAnRiver reproduction confirmed the wrapper target has `generator_function=spi_test_configs`, not `verilog_dv_test_cfg`