### PR TITLE
Refresh Bazel outputs before compile reuse

### DIFF
--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -766,10 +766,12 @@ seed and original simulator options. Run it directly from any directory. Set
   Bazel configuration files (including `.bazelignore`) inside the main
   workspace. External IP/VIP repositories are intentionally excluded; run
   `bazel clean` after changing them.
-- When discovery is cached and the existing TB runfiles and test-config outputs
-  are still present, simmer reuses those outputs instead of repeating
-  `bazel build`. A changed workspace metadata file invalidates discovery and
-  rebuilds them; `bazel clean` removes the outputs and also forces a rebuild.
+- Cached discovery reuses existing test-config outputs, but normal compile
+  runs still issue an incremental `bazel build` for each selected testbench.
+  This refreshes runfiles and compile-input digests after Verilog source
+  changes while letting Bazel reuse unchanged outputs. Targets built during
+  the current discovery pass are not built twice. A changed workspace metadata
+  file invalidates discovery, and `bazel clean` removes all cached outputs.
 - Passing tests are removed by default. `--nt` intentionally retains them.
 - Do not enable waves, coverage, SmartLog, ICO artifacts or `--nt` in routine
   throughput regressions.

--- a/lib/job_lib.py
+++ b/lib/job_lib.py
@@ -1188,8 +1188,9 @@ class BazelTBJob(Job):
         self.bazel_targets = list(dict.fromkeys(self.bazel_targets))
         prebuilt_targets = set(prebuilt_targets)
         if getattr(rcfg, "use_cached_discovery", False):
-            prebuilt_targets.update(target for target in self.bazel_targets
-                                    if self._cached_target_output_exists(rcfg.proj_dir, target))
+            prebuilt_targets.update(
+                target for target in self.bazel_targets
+                if target != self.bazel_target and self._cached_test_cfg_output_exists(rcfg.proj_dir, target))
         self.bazel_targets = [target for target in self.bazel_targets if target not in prebuilt_targets]
         super(BazelTBJob, self).__init__(rcfg, self)
         self.vcomper = vcomper
@@ -1210,11 +1211,9 @@ class BazelTBJob(Job):
             command.extend(self.bazel_targets)
             self.main_cmdline = shlex.join(command)
 
-    def _cached_target_output_exists(self, project_dir, target):
+    def _cached_test_cfg_output_exists(self, project_dir, target):
         package, target_name = target.split(":", 1)
         output_dir = os.path.join(project_dir, "bazel-bin", package[2:])
-        if target == self.bazel_target:
-            return os.path.isdir(os.path.join(output_dir, "{}.runfiles".format(target_name), "__main__"))
         return os.path.isfile(os.path.join(output_dir, "{}_dynamic_args.py".format(target_name)))
 
     def pre_run(self):

--- a/tests/job_manager_launch_test.py
+++ b/tests/job_manager_launch_test.py
@@ -301,7 +301,7 @@ class JobManagerLaunchTest(unittest.TestCase):
 
         self.assertEqual("bazel build //pkg/tests:second", job.main_cmdline)
 
-    def test_cached_discovery_reuses_existing_tb_and_test_cfg_outputs(self):
+    def test_cached_discovery_rebuilds_tb_to_refresh_source_outputs(self):
         project_dir = tempfile.mkdtemp()
         os.makedirs(os.path.join(project_dir, "bazel-bin", "pkg", "tb.runfiles", "__main__"))
         tests_dir = os.path.join(project_dir, "bazel-bin", "pkg", "tests")
@@ -318,8 +318,7 @@ class JobManagerLaunchTest(unittest.TestCase):
 
         job = BazelTBJob(rcfg, "//pkg:tb", vcomper, additional_targets=["//pkg/tests:first"])
 
-        self.assertNotIn("bazel build", job.main_cmdline)
-        self.assertIn("cached or discovery-built", job.main_cmdline)
+        self.assertEqual("bazel build //pkg:tb", job.main_cmdline)
 
     def test_cached_discovery_rebuilds_outputs_missing_after_bazel_clean(self):
         project_dir = tempfile.mkdtemp()
@@ -335,7 +334,7 @@ class JobManagerLaunchTest(unittest.TestCase):
 
         job = BazelTBJob(rcfg, "//pkg:tb", vcomper, additional_targets=["//pkg/tests:first"])
 
-        self.assertEqual("bazel build //pkg/tests:first", job.main_cmdline)
+        self.assertEqual("bazel build //pkg:tb //pkg/tests:first", job.main_cmdline)
 
     def test_no_compile_still_builds_test_configs(self):
         log = _Logger()


### PR DESCRIPTION
## Summary

- keep cached test discovery while still running an incremental Bazel build for selected testbenches
- refresh runfiles and precomputed compile-input digests after Verilog source changes
- continue reusing unchanged test-config outputs and targets already built during the current discovery pass

## Root cause

Cached discovery treated an existing testbench runfiles directory as proof that the Bazel outputs were current. After an SV edit, simmer skipped the Bazel build and read the stale precomputed compile-input digest, so VCS incorrectly reported a compile-cache hit.

## Validation

- focused BazelTBJob cache/build tests: 5 passed
- documentation tests: 5 passed
- Python syntax compilation
- YAPF 0.43.0 diff check
- `git diff --check`

The full Windows job-manager module retains existing POSIX signal/process-group failures unrelated to this change.