### PR TITLE
Enable VCS read access for interface waves

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ VCS wave capture uses FSDB. These commands cover the generated simmer flow:
 # Default hdl_top scope, all hierarchy, full simulation.
 simmer -t 'sys_tb:smoke_test@1' --simulator VCS --waves
 
-# Selected scopes at UCLI depth 8: each scope plus seven nested levels.
+# Selected RTL and SystemVerilog interface scopes at UCLI depth 8.
 simmer -t 'sys_tb:smoke_test@1' --simulator VCS \
-  --waves hdl_top.dut hdl_top.env --wave-depth 8
+  --waves hdl_top.dut hdl_top.spi_apb_if hdl_top.mcp_axi_if --wave-depth 8
 
 # Capture only the 1000 ns through 50000 ns interval.
 simmer -t 'sys_tb:smoke_test@1' --simulator VCS \
@@ -129,6 +129,9 @@ simmer -t 'sys_tb:smoke_test@1' --simulator VCS --waves \
 ```
 
 The generated FSDB controls are:
+
+VCS wave builds use `-debug_access+r`, providing signal read access without
+enabling VPI or UVM transaction recording.
 
 | simmer argument | Effect |
 |-----------------|--------|

--- a/bin/templates/vcs_compile_template.sh.j2
+++ b/bin/templates/vcs_compile_template.sh.j2
@@ -47,7 +47,7 @@ cd {{ bazel_runfiles_main|shell_quote }}
     {% else -%}
       -kdb \
     {% endif -%}
-    -debug_access \
+    -debug_access+r \
   {% endif -%}
   {% if debug_mode == "gui" -%}
     -kdb \

--- a/bin/templates/vcs_three_step_compile_template.sh.j2
+++ b/bin/templates/vcs_three_step_compile_template.sh.j2
@@ -154,7 +154,7 @@ run_vlogan_group \
     {% else -%}
       -kdb \
     {% endif -%}
-    -debug_access \
+    -debug_access+r \
   {% endif -%}
   {% if debug_mode == "gui" -%}
     -kdb \

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -502,7 +502,8 @@ simmer -t <bench>:<test> --simulator VCS --vcs-xprop F
 ```
 
 VCS `--waves` is the lightweight signal-dump mode. It compiles with `-kdb`
-and the base `-debug_access`, but does not enable VPI, SmartLog, or UVM
+and `-debug_access+r`, which gives FSDB read access to RTL signals and selected
+SystemVerilog interface signals, but does not enable VPI, SmartLog, or UVM
 transaction-recording defines. VCS cannot combine SmartLog's `-sml` with
 `-fastpartcomp=jN`; use `--smartlog --no-vcs-partcomp` when Verdi log/source
 correlation is needed. `--gui` remains the full interactive-debug mode: it
@@ -511,7 +512,9 @@ enables full reverse-debug access and explicitly adds
 SmartLog.
 
 The signal-only mode avoids the callback, driver, class, and VPI capabilities
-used for transaction-aware debug. GUI mode keeps VPI and UVM recording.
+used for transaction-aware debug. GUI mode keeps VPI and UVM recording. Add
+interface instances such as `hdl_top.spi_apb_if` and `hdl_top.mcp_axi_if` to
+`--waves` when they are outside a narrower RTL probe scope.
 
 `--xprop` remains a compatibility spelling for VCS. Use `--vcs-xprop` in new
 VCS commands so simulator-specific controls stay grouped in `simmer -h`.
@@ -521,13 +524,13 @@ VCS wave dumping supports FSDB only.
 ### FSDB probe and viewer flow
 
 The default FSDB command probes `hdl_top` to depth 10. VCS wave builds retain
-`-kdb` and base debug access for source-code visibility, while FSDB contains HDL
-signals rather than the UVM VIP class hierarchy. Limit scope and time further
-when possible:
+`-kdb` and `-debug_access+r` for source-code visibility and read access to RTL
+and SystemVerilog interface signals, while FSDB contains signals rather than
+the UVM VIP class hierarchy. Limit scope and time further when possible:
 
 ```bash
 simmer -t <bench>:<test> --simulator VCS \
-  --waves hdl_top.dut hdl_top.env \
+  --waves hdl_top.dut hdl_top.spi_apb_if hdl_top.mcp_axi_if \
   --wave-depth 8 --wave-start 1000 --wave-end 50000
 ```
 

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -879,7 +879,8 @@ run_bounded_process([
             )
 
         waves = render("waves", waves=[])
-        self.assertIn("-debug_access", waves)
+        self.assertIn("-debug_access+r", waves)
+        self.assertNotIn("-debug_access \\", waves)
         self.assertNotIn("-debug_access+pp", waves)
         self.assertNotIn("+vpi", waves)
         self.assertNotIn("-debug_access+all+designer+simctrl", waves)
@@ -2281,7 +2282,7 @@ run_bounded_process([
             additional_defines=["PROJECT_DEFINE"],
             bazel_runfiles_main=shell_path(runfiles),
             cov_opts="",
-            debug_mode="default",
+            debug_mode="waves",
             options=SimpleNamespace(
                 dtl=False,
                 fgp=None,
@@ -2337,6 +2338,8 @@ run_bounded_process([
         self.assertIn("+define+PROJECT_DEFINE", first_analysis)
         self.assertNotIn(shell_path(vlogan_args), first_analysis)
         self.assertEqual("vcs", elaboration[0])
+        self.assertIn("-debug_access+r", elaboration)
+        self.assertNotIn("-debug_access", elaboration)
         self.assertIn("-partcomp", elaboration)
         self.assertIn("-fastpartcomp=j2", elaboration)
         self.assertIn(shell_path(elab_args), elaboration)


### PR DESCRIPTION
## Summary

- compile lightweight VCS `--waves` builds with `-debug_access+r` in both the two-step and three-step flows
- preserve the existing lightweight boundary: no VPI, SmartLog, or UVM transaction recorder is enabled implicitly
- document explicit RTL and SystemVerilog interface scopes such as `hdl_top.spi_apb_if` and `hdl_top.mcp_axi_if`
- extend runtime contract coverage for both compile templates

## Why

The previous base `-debug_access` setting did not provide the read capability required to reliably dump SystemVerilog interface signals. VCS/Verdi reports this as a request to add `-debug_access+r`.

## Validation

- focused two-step waves/GUI runtime contract test
- focused three-step incremental-analysis runtime contract test
- `py -3 tests/docs_test.py` (5 tests)
- YAPF diff check
- `git diff --check`

Real VCS compilation was not run locally; licensed validation remains on the configured Red Hat/SHICloud environment.