### PR TITLE
Harden simulator cache, waves, and scheduler paths

### DIFF
--- a/bin/check_test.py
+++ b/bin/check_test.py
@@ -160,29 +160,39 @@ def scan_static_log(filepath, error_limit, extra_error_regex=None, required_fini
             if data.find(b"TEST_CHECK_") != -1:
                 return None
 
+            # Regexes supplied by projects commonly anchor a pattern with `$`.
+            # A byte regex sees the `\r` in a CRLF line ending, so `$` does not
+            # match before `\r\n` even though the text-mode fallback does. Keep
+            # the mmap fast path for the common LF case, and normalize only
+            # logs that actually contain CRLF line endings so both paths have
+            # identical matching semantics.
+            search_data = data
+            if data.find(b"\r\n") != -1:
+                search_data = data[:].replace(b"\r\n", b"\n")
+
             error_lines = []
             seen_line_starts = set()
             error_patterns = [err_regex.pattern]
             if extra_error_regex is not None:
                 error_patterns.append(extra_error_regex.pattern)
             byte_error_regex = re.compile(compile_patterns(error_patterns).pattern.encode('utf-8'), re.MULTILINE)
-            for match in byte_error_regex.finditer(data):
-                line_start = data.rfind(b'\n', 0, match.start()) + 1
+            for match in byte_error_regex.finditer(search_data):
+                line_start = search_data.rfind(b'\n', 0, match.start()) + 1
                 if line_start in seen_line_starts:
                     continue
-                line_end = data.find(b'\n', match.end())
-                line_end = len(data) if line_end == -1 else line_end + 1
-                error_lines.append(decode_line(data[line_start:line_end]))
+                line_end = search_data.find(b'\n', match.end())
+                line_end = len(search_data) if line_end == -1 else line_end + 1
+                error_lines.append(decode_line(search_data[line_start:line_end]))
                 seen_line_starts.add(line_start)
                 if len(error_lines) >= error_limit:
                     break
-            seed_lines = find_lines(data, [b"SVSEED", b"random seed used"])
-            run_time_lines = find_lines(data, [b"real\t"], required_marker=b"user\t")
+            seed_lines = find_lines(search_data, [b"SVSEED", b"random seed used"])
+            run_time_lines = find_lines(search_data, [b"real\t"], required_marker=b"user\t")
             if required_finish_regex is None:
-                found_finish = any(data.find(signature.encode('utf-8')) != -1 for signature in finish_signatures)
+                found_finish = any(search_data.find(signature.encode('utf-8')) != -1 for signature in finish_signatures)
             else:
                 required_bytes = re.compile(required_finish_regex.pattern.encode('utf-8'), re.MULTILINE)
-                found_finish = required_bytes.search(data) is not None
+                found_finish = required_bytes.search(search_data) is not None
             return error_lines, seed_lines, run_time_lines, found_finish
 
 

--- a/bin/lint_parser_ascent.py
+++ b/bin/lint_parser_ascent.py
@@ -80,6 +80,7 @@ class AscentMessage(object):
 class AscentLintLog(object):
 
     def __init__(self, path, log):
+        self.log = log
         self.issues = []
         self.files_with_notes = {}
         self.dirs_with_notes = {}
@@ -120,8 +121,17 @@ class AscentLintLog(object):
                 continue
 
             # Map from the base path name to the bazel-relative path name to be able to find waivers
-            relative_filename = self.file_map[filename]
-            with open(relative_filename, errors='replace') as filep:
+            # Recent Ascent reports can omit the optional file-definition
+            # table and may already contain a usable path.  Falling back to
+            # the rendered filename keeps waiver parsing alive instead of
+            # turning a valid lint report into a KeyError.
+            relative_filename = self.file_map.get(filename, filename)
+            try:
+                filep = open(relative_filename, errors='replace')
+            except OSError as exc:
+                log.warning("Skipping waiver scan for missing source %s: %s", relative_filename, exc)
+                continue
+            with filep:
                 for i, line in enumerate(filep.readlines()):
                     match = LINE_WAIVER_REGEXP.search(line)
                     if match:
@@ -207,6 +217,7 @@ class AscentLintLog(object):
     def prep_file_stats(self):
 
         self.files_with_notes = {}
+        self.dirs_with_notes = {}
 
         for issue in self.issues:
             if not issue.waived:
@@ -220,10 +231,10 @@ class AscentLintLog(object):
             while os.path.basename(file_path) not in ['rtl', 'analog'] and loop_count <= 10:
                 base_dir = os.path.basename(file_path)
                 file_path = os.path.split(file_path)[0]
-                loop_count += 10
+                loop_count += 1
 
-            if loop_count == 10:
-                log.info("Couldn't resolve base directory for {}".format(orig_path))
+            if loop_count > 10 or base_dir is None:
+                self.log.info("Couldn't resolve base directory for {}".format(orig_path))
                 return orig_path
 
             return os.path.join(file_path, base_dir)

--- a/bin/lint_parser_hal.py
+++ b/bin/lint_parser_hal.py
@@ -162,6 +162,7 @@ class HalLintLog(object):
     def prep_file_stats(self):
 
         self.files_with_notes = {}
+        self.dirs_with_notes = {}
 
         for issue in self.issues:
             if not issue.waived:
@@ -175,9 +176,9 @@ class HalLintLog(object):
             while os.path.basename(file_path) not in ['rtl', 'analog'] and loop_count <= 10:
                 base_dir = os.path.basename(file_path)
                 file_path = os.path.split(file_path)[0]
-                loop_count += 10
+                loop_count += 1
 
-            if loop_count == 10:
+            if loop_count > 10 or base_dir is None:
                 log.info("Couldn't resolve base directory for {}".format(orig_path))
                 return orig_path
 

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -490,7 +490,7 @@ Batch VCS defaults are kept light:
 - no default `+vpi`
 - no default xprop
 - no default smartlog
-- `-fastpartcomp=j8`
+- allocation-aware `-fastpartcomp=jN` (the detected LSF/Slurm or affinity allocation)
 
 Enable debug features explicitly:
 

--- a/lib/compile_cache.py
+++ b/lib/compile_cache.py
@@ -144,8 +144,14 @@ def discover_filelist_inputs(filelist_path, working_directory):
     parsed_filelists = set()
     pending = [(root_filelist, working_directory)]
 
+    def unquote(value):
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            return value[1:-1]
+        return value
+
     def resolve(path, base_directory):
-        expanded = os.path.expanduser(os.path.expandvars(path))
+        expanded = os.path.expanduser(os.path.expandvars(unquote(path)))
         return os.path.abspath(expanded if os.path.isabs(expanded) else os.path.join(base_directory, expanded))
 
     def add_path(path, base_directory, include_directory=False):
@@ -166,7 +172,14 @@ def discover_filelist_inputs(filelist_path, working_directory):
         discovered.add(current_filelist)
         try:
             with open(current_filelist, "r", encoding="utf-8", errors="surrogateescape") as filep:
-                tokens = shlex.split(filep.read(), comments=True, posix=True)
+                # Simulator filelists are usually POSIX shell syntax, but the
+                # library is also exercised on Windows where drive-letter
+                # paths contain backslashes.  ``posix=True`` treats those
+                # backslashes as escapes and silently turns e.g.
+                # ``C:\\work\\dut.sv`` into ``C:workdut.sv``.  Preserve
+                # native Windows paths while retaining the existing POSIX
+                # parsing rules on licensed Linux hosts.
+                tokens = [unquote(token) for token in shlex.split(filep.read(), comments=True, posix=os.name != "nt")]
         except ValueError:
             continue
 

--- a/lib/job_lib.py
+++ b/lib/job_lib.py
@@ -222,8 +222,8 @@ class Job():
     def add_dependency(self, dep):
         if not dep:
             self.log.error("%s added null dep", self)
-        else:
-            self._dependencies.append(dep)
+            return
+        self._dependencies.append(dep)
         dep._children.append(self)
         dep.increase_priority(self.priority)
 
@@ -1005,6 +1005,9 @@ class JobManager():
         self.exited_prematurely = True
         self._done_grace_exit = True
         self.log.warn("Exceeded quit count. Graceful exit.")
+        for job in self._todo + self._ready:
+            if not job.jobstatus.completed:
+                job.jobstatus = JobStatus.SKIPPED
         self._skipped.extend(self._todo)
         self._todo = []
         self._skipped.extend(self._ready)

--- a/lib/rv_utils.py
+++ b/lib/rv_utils.py
@@ -254,11 +254,19 @@ def calc_simresults_location(checkout_path):
     sim_results_home = os.path.join(sim_results_root, username)
     os.makedirs(sim_results_home, exist_ok=True)
 
+    # Keep result directories below the configured state root on both POSIX
+    # and Windows.  The old expression only recognized ``username/`` with a
+    # forward slash; on Windows an unmatched absolute checkout path was then
+    # passed to ``os.path.join`` and discarded ``sim_results_home`` entirely.
+    path_parts = re.split(r'[\\/]', os.path.normpath(os.fspath(checkout_path)))
     try:
-        checkout_path = re.search(r'{}/(.*)'.format(username), checkout_path).group(1)
-    except AttributeError:
-        pass
-    checkout_path = checkout_path.replace('/', '_')
+        username_index = path_parts.index(username)
+    except ValueError:
+        relative_checkout = os.path.normpath(os.fspath(checkout_path))
+    else:
+        relative_checkout = os.sep.join(path_parts[username_index + 1:])
+    checkout_path = relative_checkout.replace('/', '_').replace('\\', '_').replace(':', '_')
+    checkout_path = checkout_path.lstrip('/\\') or 'checkout'
     regression_directory = checkout_path
     regression_directory = os.path.join(sim_results_home, regression_directory)
     return regression_directory

--- a/lib/simulators/vcs_options.py
+++ b/lib/simulators/vcs_options.py
@@ -151,5 +151,7 @@ def validate_vcs_runtime_options(options, parser):
     if options.waves is not None:
         if options.wave_type is None:
             options.wave_type = 'fsdb'
+        else:
+            options.wave_type = options.wave_type.lower()
         if options.wave_type != 'fsdb':
             parser.error("VCS supports only --wave-type fsdb. Stopping before Bazel starts.")

--- a/lib/simulators/xcelium.py
+++ b/lib/simulators/xcelium.py
@@ -522,7 +522,11 @@ class XceliumSimulator(SimulatorInterface):
         if wave_type == 'vcd':
             return os.path.join(job_dir, 'waves.vcd')
         if wave_type == 'vwdb':
-            return os.path.join(job_dir, 'waves.db')
+            # xmDumpfile creates the Verisium database at the exact path passed
+            # to it.  The capture options pass ``<job_dir>/waves`` (a database
+            # directory), so use that same path when cleaning up and checking
+            # the completed artifact.
+            return os.path.join(job_dir, 'waves')
         raise ValueError("Not allowed wave: {}".format(wave_type))
 
     def setup_coverage_merge(self, vcomp_job):

--- a/lib/simulators/xcelium_options.py
+++ b/lib/simulators/xcelium_options.py
@@ -7,6 +7,8 @@ def validate_xcelium_runtime_options(options, parser):
     if options.waves is not None:
         if options.wave_type is None:
             options.wave_type = 'vwdb'
+        else:
+            options.wave_type = options.wave_type.lower()
         if options.wave_type not in ['shm', 'vcd', 'vwdb']:
             parser.error("Xcelium supports only --wave-type shm, vcd, or vwdb. Stopping before Bazel starts.")
     if options.wave_delta and (options.waves is None or options.wave_type != 'shm'):

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -99,6 +99,16 @@ py_test(
 )
 
 py_test(
+    name = "lint_parser_test",
+    timeout = "short",
+    srcs = ["lint_parser_test.py"],
+    deps = [
+        "//bin:lint_parser_ascent",
+        "//bin:lint_parser_hal",
+    ],
+)
+
+py_test(
     name = "normalize_runfiles_flist_test",
     timeout = "short",
     srcs = ["normalize_runfiles_flist_test.py"],

--- a/tests/check_test_test.py
+++ b/tests/check_test_test.py
@@ -53,6 +53,22 @@ class CheckTestFastPathTest(unittest.TestCase):
         self.assertEqual(["PROJECT FAIL\n"], errors)
         self.assertTrue(finished)
 
+    def test_project_patterns_match_crlf_logs_on_static_fast_path(self):
+        pass_regex = check_test.compile_patterns([r"^PROJECT PASS$"])
+        fail_regex = check_test.compile_patterns([r"^PROJECT FAIL$"])
+        path = Path(tempfile.mkdtemp()) / "stdout.log"
+        path.write_bytes(b"PROJECT FAIL\r\nPROJECT PASS\r\n")
+
+        errors, _, _, finished = check_test.scan_static_log(
+            path,
+            25,
+            extra_error_regex=fail_regex,
+            required_finish_regex=pass_regex,
+        )
+
+        self.assertEqual(["PROJECT FAIL\n"], errors)
+        self.assertTrue(finished)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/compile_cache_test.py
+++ b/tests/compile_cache_test.py
@@ -276,6 +276,16 @@ class CompileCacheTest(unittest.TestCase):
         for path in (nested, source, header):
             self.assertEqual(1, read_paths.count(str(path)))
 
+    def test_filelist_input_discovery_unquotes_paths_with_spaces(self):
+        root_dir = Path(tempfile.mkdtemp())
+        source = root_dir / "source files" / "dut.sv"
+        source.parent.mkdir()
+        source.write_text("module dut; endmodule\n", encoding="utf-8")
+        root = root_dir / "compile.f"
+        root.write_text('"{}"\n'.format(source), encoding="utf-8")
+
+        self.assertEqual(sorted(map(str, (root, source))), discover_filelist_inputs(root, root_dir))
+
     def test_filelist_input_discovery_uses_nested_file_directory_for_dash_capital_f(self):
         working_dir = Path(tempfile.mkdtemp())
         filelist_dir = Path(tempfile.mkdtemp())

--- a/tests/job_manager_launch_test.py
+++ b/tests/job_manager_launch_test.py
@@ -245,6 +245,15 @@ class JobManagerLaunchTest(unittest.TestCase):
 
         self.assertTrue(result_dir.startswith(os.path.join(state_dir, "simmer")))
 
+    def test_add_dependency_ignores_null_dependency(self):
+        rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1), log=_Logger())
+        job = Job(rcfg, "child")
+
+        job.add_dependency(None)
+
+        self.assertEqual([], job._dependencies)
+        self.assertEqual([], job._children)
+
     def test_bazel_tb_job_builds_runfiles_without_running_dummy_executable(self):
         log = _Logger()
         rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1, no_compile=False, no_bazel=False), log=log)
@@ -740,6 +749,27 @@ class JobManagerLaunchTest(unittest.TestCase):
             self.assertEqual(JobStatus.FAILED, job.jobstatus)
             self.assertIn(job, manager._done)
             self.assertEqual("failed to launch", result_run["launch_failures"][0]["error_message"])
+        finally:
+            manager.stop()
+
+    def test_quit_count_marks_queued_jobs_skipped(self):
+        log = _Logger()
+        rcfg = SimpleNamespace(options=SimpleNamespace(timeout=1), log=log)
+        first = Job(rcfg, "first")
+        second = Job(rcfg, "second")
+        first.job_dir = str(Path(tempfile.mkdtemp()) / "first")
+        second.job_dir = str(Path(tempfile.mkdtemp()) / "second")
+        manager = JobManager({"idle_print_seconds": 60, "quit_count": 1}, log)
+        manager.job_lib_type = _FailingRunner
+
+        try:
+            manager.add_job(first)
+            manager.add_job(second)
+            manager.wait()
+
+            self.assertEqual(JobStatus.FAILED, first.jobstatus)
+            self.assertEqual(JobStatus.SKIPPED, second.jobstatus)
+            self.assertIn(second, manager._skipped)
         finally:
             manager.stop()
 

--- a/tests/lint_parser_test.py
+++ b/tests/lint_parser_test.py
@@ -1,0 +1,67 @@
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "bin"))
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+import lint_parser_ascent
+import lint_parser_hal
+
+
+class LintParserStatsTest(unittest.TestCase):
+
+    def _issue(self, filename):
+        return SimpleNamespace(filename=str(filename), waived=False)
+
+    def test_hal_directory_stats_walk_to_rtl_root_and_reset(self):
+        root = Path(tempfile.mkdtemp())
+        source = root / "rtl" / "block" / "subblock" / "issue.sv"
+        source.parent.mkdir(parents=True)
+        source.touch()
+        parser = lint_parser_hal.HalLintLog.__new__(lint_parser_hal.HalLintLog)
+        parser.issues = [self._issue(source)]
+
+        with mock.patch.object(lint_parser_hal, "log", mock.Mock()):
+            parser.prep_file_stats()
+
+        self.assertEqual({str(root / "rtl" / "block"): 1}, parser.dirs_with_notes)
+
+        parser.issues = []
+        with mock.patch.object(lint_parser_hal, "log", mock.Mock()):
+            parser.prep_file_stats()
+        self.assertEqual({}, parser.dirs_with_notes)
+
+    def test_ascent_directory_stats_walk_to_rtl_root(self):
+        root = Path(tempfile.mkdtemp())
+        source = root / "rtl" / "block" / "subblock" / "issue.sv"
+        source.parent.mkdir(parents=True)
+        source.touch()
+        parser = lint_parser_ascent.AscentLintLog.__new__(lint_parser_ascent.AscentLintLog)
+        parser.issues = [self._issue(source)]
+
+        parser.prep_file_stats()
+
+        self.assertEqual({str(root / "rtl" / "block"): 1}, parser.dirs_with_notes)
+
+    def test_ascent_report_without_file_definition_table_uses_rendered_path(self):
+        root = Path(tempfile.mkdtemp())
+        source = root / "rtl" / "block" / "issue.sv"
+        source.parent.mkdir(parents=True)
+        source.write_text("// no waivers\n", encoding="utf-8")
+        report = root / "lint.rpt"
+        report.write_text("E RULE_ONE: {}:1 bad message New\n".format(source), encoding="utf-8")
+
+        parsed = lint_parser_ascent.AscentLintLog(str(report), mock.Mock())
+
+        self.assertEqual(1, len(parsed.errors))
+        self.assertEqual(str(source), parsed.errors[0].filename)
+        self.assertFalse(parsed.errors[0].waived)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
+++ b/tests/vcs_filelist_validation/validate_vcs_runtime_contract_test.py
@@ -1393,6 +1393,13 @@ run_bounded_process([
         with self.assertRaises(ValueError):
             self._validated(["--simulator", "XRUN", "--waves", "--wave-type", "unknown"])
 
+    def test_wave_type_validation_is_case_insensitive(self):
+        vcs_options, _ = self._validated(["--simulator", "VCS", "--waves", "--wave-type", "FSDB"])
+        xcelium_options, _ = self._validated(["--simulator", "XRUN", "--waves", "--wave-type", "VWDB"])
+
+        self.assertEqual("fsdb", vcs_options.wave_type)
+        self.assertEqual("vwdb", xcelium_options.wave_type)
+
     def test_xcelium_msie_incremental_requires_primary_snapshot_name(self):
         with self.assertRaises(SystemExit):
             parse_args(["--simulator", "XRUN", "--msie-incr"])
@@ -2420,6 +2427,9 @@ run_bounded_process([
         capture = simulator.get_wave_capture_options(test_job, "/tmp/waves.tcl")
         self.assertEqual("hdl_top", capture["default_capture"])
         self.assertIn("-debug_opts verisium_pp", capture["sim_opts"])
+        self.assertEqual(os.path.join(test_job.job_dir, "waves"), capture["waves_db"])
+        self.assertEqual(os.path.join(test_job.job_dir, "waves"),
+                         simulator.get_wave_artifact_path(test_job.job_dir, options.wave_type))
 
         vcomp = DummyVcompJob()
         Path(vcomp.bench_dir, "fox_xprop.txt").touch()


### PR DESCRIPTION
## Summary

- Make static log checks robust to CRLF output.
- Preserve Windows filelist paths, quoted paths with spaces, and simulator result paths.
- Align XRUN VWDB artifact cleanup with the path emitted by xmDumpfile.
- Harden lint parser directory accounting and missing Ascent file maps.
- Mark queued jobs skipped during graceful quit-count exits and ignore null dependencies.
- Normalize case-insensitive VCS/Xcelium waveform formats and refresh the Partition Compile documentation.

## Validation

- Focused license-free regression: 35 tests passed (1 skipped).
- Full direct Windows unittest: 150 passed, 10 skipped; remaining 2 failures and 15 errors are Windows/POSIX/Bazel-runfiles limitations (POSIX process-group signals, TEST_SRCDIR, /usr/bin/env, and executable bits).
- compileall, pyflakes, and git diff --check passed.
- Licensed VCS/Xcelium workloads were not run locally; they require the configured SHICloud bsub environment.