### PR TITLE
Improve simmer history timing and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,8 @@ reporting, MSIE, Palladium, ICO, VSO.ai and CCEX.
 
 `--no-compile` reuse is rejected when source/runfile content, an external
 compile configuration, or the selected simulator tool environment changes.
-Recent normal-run compile/start failures remain visible through `simmer --history`.
+Completed and interrupted simulations remain visible through `simmer --history`;
+failures that prevent every test from starting are not recorded.
 
 ### Python Dependencies
 rules_verilog uses the Python libraries listed in `requirements.txt`, but it

--- a/bin/args_parse/common.py
+++ b/bin/args_parse/common.py
@@ -240,6 +240,19 @@ def add_regression_arguments(parser):
         type=int,
         help='Print retained simulation records and exit. With no value show 10; otherwise require a positive count.')
     regression_group.add_argument(
+        '--history-bench',
+        '--his-bench',
+        dest='history_bench',
+        default=None,
+        help='Show history for this exact bench name. Used alone, query the most recent 10 matching records.')
+    regression_group.add_argument(
+        '--history-fail',
+        '--his-fail',
+        dest='history_fail',
+        default=False,
+        action='store_true',
+        help='Show failed history only. Used alone, query the most recent 10 matching records.')
+    regression_group.add_argument(
         '--no-stdout',
         default=False,
         action='store_true',

--- a/bin/args_parse/parser.py
+++ b/bin/args_parse/parser.py
@@ -123,8 +123,17 @@ def parse_args(argv):
         parser.error("--uvm-max-quit-count must be non-negative (0 disables the limit).")
     if options.idle_print_seconds < 1:
         parser.error("--idle-print-seconds must be a positive integer.")
+    if options.history_bench is not None:
+        options.history_bench = options.history_bench.strip()
+        if not options.history_bench:
+            parser.error("--history-bench requires a non-empty bench name.")
+    if options.history_bench is not None or options.history_fail:
+        if options.history is None:
+            options.history = 10
     if options.history is not None and options.history < 1:
         parser.error("--history must be a positive integer.")
+    if options.history is not None and options.tests:
+        parser.error("History query options cannot be combined with -t/--tests.")
     if options.timeout < 0:
         parser.error("--timeout must be non-negative (0 disables the timeout).")
     options.simulator_was_explicit = simulator_explicitly_requested(argv)

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -1596,6 +1596,8 @@ def main(rcfg, options):
 
 def persist_simmer_results(rcfg, fatal=True):
     """Persist local history; inability to do so is a command failure."""
+    if not simmer_results.should_save_run(rcfg.simmer_results_run):
+        return True
     try:
         simmer_results.save_run(rcfg.proj_dir, rcfg.simmer_results_run)
     except Exception as exc:
@@ -1630,8 +1632,8 @@ def finalize_interrupted_run(rcfg,
         return
     if jm is not None:
         for job in jm.interrupted_jobs:
-            if isinstance(job, TestJob):
-                simmer_results.record_test_job(run, job, status="INTERRUPTED")
+            if isinstance(job, TestJob) and job.job_start_time is not None:
+                simmer_results.record_test_job(run, job, status="INTERRUPTED", simulation_started=True)
             elif isinstance(job, VCompJob):
                 simmer_results.record_compile_job(run, job, status="INTERRUPTED")
     simmer_results.finalize_run(run, backend_finalize_failed=True)
@@ -1642,7 +1644,13 @@ if __name__ == '__main__':
     options = parse_args(sys.argv[1:])
     if options.history is not None:
         history_use_color = True if options.use_color else None
-        simmer_results.print_history(options.proj_dir, options.history, use_color=history_use_color)
+        simmer_results.print_history(
+            options.proj_dir,
+            options.history,
+            use_color=history_use_color,
+            bench=options.history_bench,
+            failed_only=options.history_fail,
+        )
         sys.exit(0)
     options.simmer_argv = sys.argv[:]
     verbosity = cmn_logging.DEBUG if options.tool_debug else cmn_logging.INFO

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -788,9 +788,9 @@ seed and original simulator options. Run it directly from any directory. Set
 ## Simulation history
 
 Normal simulation invocations are recorded in `.simmer_results.json` at the
-project root, including compile and launch failures that prevent a test from
-starting. The file is local run state and is intended for quick lookup of recent
-outputs.
+project root after at least one simulation starts. Compile or launch failures
+that prevent every test from starting are not recorded. The file is local run
+state and is intended for quick lookup of recent outputs.
 
 Print the most recent 10 runs:
 
@@ -806,19 +806,47 @@ simmer --history 20
 simmer --his 20
 ```
 
-Each entry includes the original `simmer` command, compile log, and result log.
-For a single test with wave dumping enabled, the history also shows the
-generated `run_waves.sh` path. For multi-test regressions, the result path is
-the regression log rather than every individual case log.
+Filter by exact bench name or failure status. A filter used without
+`--history`/`--his` automatically queries the most recent 10 matching records:
+
+```bash
+simmer --history-bench sys_tb
+simmer --his-bench sys_tb
+simmer --history-fail
+simmer --his-fail
+```
+
+Combine filters with a custom count:
+
+```bash
+simmer --his 20 --his-bench sys_tb --his-fail
+```
+
+Filters are applied before the count, so this example returns the most recent
+20 failed `sys_tb` records. Bench and failure filters use AND semantics. History
+query options cannot be combined with `-t`/`--tests`; a query with no matches
+prints `No matching simmer history found.`.
+
+Each entry includes the original `simmer` command, compile log, result log, and
+compile/simulation elapsed time on the first line. Parallel jobs are measured as
+the union of their active intervals rather than by summing every case. Compile
+reuse is shown as `compile reused`. For a single test with wave dumping enabled,
+the history also shows the generated `run_waves.sh` path. For multi-test
+regressions, the result path is the regression log rather than every individual
+case log.
 
 Example:
 
 ```text
-[1] 2026-07-09 15:03:04  FAILED  87/100 pass, 13 fail
+[1] 2026-07-09 15:03:04  FAILED  [tests: 87 passed | 13 failed]  [compile 00:03:12 | simulate 00:38:41]
 cmd:     simmer -t sys_tb:*@10
 compile: /sim/sys_tb/cmp.log
 result:  /sim/regression.log
 ```
+
+Single-test entries omit the redundant pass/fail count and show only the final
+run status. Multi-test regressions use the explicit `[tests: ...]` summary so
+case results are not confused with compile and simulation phases.
 
 Status words and pass/fail labels are colorized when output goes to a terminal.
 Use `--use-color` to force color output:
@@ -830,4 +858,7 @@ simmer --use-color --history
 Discovery-only and explicit compile-only invocations are not recorded. For a
 started test, `duration_s` is the main simulator command time and
 `wall_duration_s` is the complete test job time; a failure before the simulator
-starts leaves `duration_s` unset.
+starts leaves `duration_s` unset. Run-level `timing.compile_elapsed_s` and
+`timing.simulate_elapsed_s` retain millisecond precision in the JSON file while
+the history display uses `HH:MM:SS`. Older records without run-level timing
+remain readable and display `-` for the missing values.

--- a/lib/simmer_results.py
+++ b/lib/simmer_results.py
@@ -211,12 +211,7 @@ def record_compile_job(run, vcomp_job, status=None):
     _upsert_by_key(run["compile"], "vcomp_target", compile_record)
 
 
-def record_test_job(run,
-                    test_job,
-                    waves_script=None,
-                    waves_path=None,
-                    status=None,
-                    simulation_started=None):
+def record_test_job(run, test_job, waves_script=None, waves_path=None, status=None, simulation_started=None):
     if run is None:
         return
     waves_enabled = test_job.rcfg.options.waves is not None
@@ -473,8 +468,7 @@ def _format_timing(run):
 
 
 def _is_failed_history_run(run):
-    return (run.get("status") in ("FAILED", "COMPILE_FAILED")
-            or int(run.get("summary", {}).get("failed", 0) or 0) > 0)
+    return (run.get("status") in ("FAILED", "COMPILE_FAILED") or int(run.get("summary", {}).get("failed", 0) or 0) > 0)
 
 
 def _filter_history_runs(runs, bench=None, failed_only=False):
@@ -507,7 +501,8 @@ def format_history(project_dir, count, use_color=None, bench=None, failed_only=F
         if lines:
             lines.append("")
         heading = [
-            "[{}] {}".format(index, run.get("finished_at") or run.get("started_at") or "-"),
+            "[{}] {}".format(index,
+                             run.get("finished_at") or run.get("started_at") or "-"),
             _color_status(run.get("status", "-"), use_color),
         ]
         test_summary = _format_test_summary(run, use_color=use_color)

--- a/lib/simmer_results.py
+++ b/lib/simmer_results.py
@@ -3,6 +3,7 @@
 
 import datetime
 import json
+import math
 import os
 import shlex
 import sys
@@ -10,7 +11,7 @@ import uuid
 from contextlib import contextmanager
 
 RESULTS_FILENAME = ".simmer_results.json"
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 MAX_RUNS = 100
 COLOR_GREEN = "\033[0;32m"
 COLOR_RED = "\033[0;31m"
@@ -38,6 +39,93 @@ def _run_id():
     return uuid.uuid4().hex
 
 
+def _duration_seconds(value):
+    if value is None:
+        return None
+    try:
+        duration = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(duration) or duration < 0:
+        return None
+    return round(duration, 3)
+
+
+def _record_job_interval(record, job, stopped_at=None):
+    started_at = getattr(job, "job_start_time", None)
+    finished_at = getattr(job, "job_stop_time", None) or stopped_at
+    if started_at is None or finished_at is None:
+        return
+    try:
+        started_at_s = started_at.timestamp()
+        finished_at_s = finished_at.timestamp()
+    except (AttributeError, OSError, OverflowError, ValueError):
+        return
+    if finished_at_s < started_at_s:
+        return
+    record["_elapsed_interval_s"] = [started_at_s, finished_at_s]
+
+
+def _consume_elapsed_time(records):
+    intervals = []
+    for record in records:
+        interval = record.pop("_elapsed_interval_s", None)
+        if not isinstance(interval, list) or len(interval) != 2:
+            continue
+        start, stop = interval
+        if not all(isinstance(value, (int, float)) and math.isfinite(value) for value in interval):
+            continue
+        if stop >= start:
+            intervals.append((start, stop))
+    if not intervals:
+        return None
+
+    intervals.sort()
+    elapsed_s = 0.0
+    current_start, current_stop = intervals[0]
+    for start, stop in intervals[1:]:
+        if start <= current_stop:
+            current_stop = max(current_stop, stop)
+            continue
+        elapsed_s += current_stop - current_start
+        current_start, current_stop = start, stop
+    elapsed_s += current_stop - current_start
+    return round(elapsed_s, 3)
+
+
+def _finalize_timing(run):
+    timing = run.setdefault("timing", {})
+    compile_elapsed_s = _consume_elapsed_time(run.get("compile", []))
+    tests = run.get("tests", [])
+    started_tests = [test for test in tests if test.get("simulation_started", True)]
+    for test in tests:
+        if not test.get("simulation_started", True):
+            test.pop("_elapsed_interval_s", None)
+    simulate_elapsed_s = _consume_elapsed_time(started_tests)
+    if compile_elapsed_s is not None:
+        timing["compile_elapsed_s"] = compile_elapsed_s
+    else:
+        timing.setdefault("compile_elapsed_s", None)
+    if simulate_elapsed_s is not None:
+        timing["simulate_elapsed_s"] = simulate_elapsed_s
+    else:
+        timing.setdefault("simulate_elapsed_s", None)
+
+    compile_records = run.get("compile", [])
+    cache_reused = bool(compile_records) and all(
+        bool(record.get("metrics", {}).get("compile_cache_hit")) for record in compile_records)
+    timing["compile_reused"] = bool(timing.get("compile_reused") or cache_reused)
+
+
+def _collect_benches(run):
+    benches = set(run.get("benches", []))
+    for record in run.get("compile", []) + run.get("tests", []):
+        bench = record.get("bench")
+        if bench:
+            benches.add(bench)
+    return sorted(benches)
+
+
 @contextmanager
 def _store_lock(path):
     with open(path + ".lock", "a+b") as lock:
@@ -63,6 +151,7 @@ def _store_lock(path):
 
 
 def create_run(argv, rcfg, planned_tests):
+    options = getattr(rcfg, "options", None)
     return {
         "run_id": _run_id(),
         "started_at": _timestamp(),
@@ -83,7 +172,13 @@ def create_run(argv, rcfg, planned_tests):
         },
         "compile": [],
         "tests": [],
+        "benches": [],
         "launch_failures": [],
+        "timing": {
+            "compile_elapsed_s": None,
+            "simulate_elapsed_s": None,
+            "compile_reused": bool(getattr(options, "no_compile", False)),
+        },
     }
 
 
@@ -104,14 +199,24 @@ def record_compile_job(run, vcomp_job, status=None):
         "status": status or vcomp_job.jobstatus.name,
         "compile_dir": vcomp_job.job_dir,
         "cmp_log": vcomp_job.log_path,
-        "duration_s": int(getattr(vcomp_job, "duration_s", 0) or 0),
+        "duration_s": _duration_seconds(getattr(vcomp_job, "duration_s", 0) or 0),
         "metrics": getattr(vcomp_job, "compile_metrics", {}),
         "error_message": getattr(vcomp_job, "error_message", None),
     }
+    _record_job_interval(
+        compile_record,
+        vcomp_job,
+        stopped_at=datetime.datetime.now() if status == "INTERRUPTED" else None,
+    )
     _upsert_by_key(run["compile"], "vcomp_target", compile_record)
 
 
-def record_test_job(run, test_job, waves_script=None, waves_path=None, status=None):
+def record_test_job(run,
+                    test_job,
+                    waves_script=None,
+                    waves_path=None,
+                    status=None,
+                    simulation_started=None):
     if run is None:
         return
     waves_enabled = test_job.rcfg.options.waves is not None
@@ -123,8 +228,10 @@ def record_test_job(run, test_job, waves_script=None, waves_path=None, status=No
             "exists": bool(waves_path and os.path.exists(waves_path)),
         })
 
-    wall_duration_s = int(getattr(test_job, "duration_s", 0) or 0)
+    wall_duration_s = _duration_seconds(getattr(test_job, "duration_s", 0) or 0)
     simulation_duration_s = getattr(test_job, "simulation_duration_s", None)
+    if simulation_started is None:
+        simulation_started = simulation_duration_s is not None
     test_record = {
         "bench": test_job.vcomper.name,
         "test": test_job.name,
@@ -133,7 +240,8 @@ def record_test_job(run, test_job, waves_script=None, waves_path=None, status=No
         "iteration": test_job.iteration,
         "seed": getattr(test_job, "seed", None),
         "status": status or test_job.jobstatus.name,
-        "duration_s": int(simulation_duration_s) if simulation_duration_s is not None else None,
+        "simulation_started": bool(simulation_started),
+        "duration_s": _duration_seconds(simulation_duration_s),
         "wall_duration_s": wall_duration_s,
         "compile_dir": test_job.vcomper.job_dir,
         "sim_dir": test_job.job_dir,
@@ -142,6 +250,11 @@ def record_test_job(run, test_job, waves_script=None, waves_path=None, status=No
         "waves": waves,
         "error_message": getattr(test_job, "error_message", None),
     }
+    _record_job_interval(
+        test_record,
+        test_job,
+        stopped_at=datetime.datetime.now() if status == "INTERRUPTED" else None,
+    )
     for index, existing in enumerate(run["tests"]):
         if all(existing.get(key) == test_record.get(key) for key in ("target", "iteration", "seed")):
             run["tests"][index] = test_record
@@ -169,6 +282,8 @@ def finalize_run(run, regression_log_path=None, backend_finalize_failed=False):
         "skipped": skipped,
         "total": planned_tests,
     }
+    _finalize_timing(run)
+    run["benches"] = _collect_benches(run)
 
     if backend_finalize_failed:
         run["status"] = "FAILED"
@@ -216,7 +331,14 @@ def load_store(project_dir):
     return store
 
 
+def should_save_run(run):
+    """Return whether at least one simulation produced a result record."""
+    return bool(run and any(test.get("simulation_started", True) for test in run.get("tests", [])))
+
+
 def save_run(project_dir, run, max_runs=MAX_RUNS):
+    if not should_save_run(run):
+        return False
     stored_run = dict(run)
     if int(run.get("planned_tests") or len(run["tests"])) > 1 and len(run["tests"]) > 1:
         representative = next(
@@ -249,6 +371,7 @@ def save_run(project_dir, run, max_runs=MAX_RUNS):
         finally:
             if os.path.exists(temp_path):
                 os.remove(temp_path)
+    return True
 
 
 def _select_compile_log(run):
@@ -287,20 +410,27 @@ def _color_word(word, color, use_color):
     return "{}{}{}".format(color, word, COLOR_NC)
 
 
-def _format_pass_summary(run, use_color=False):
+def _format_test_summary(run, use_color=False):
     summary = run.get("summary", {})
     passed = summary.get("passed", 0)
     failed = summary.get("failed", 0)
     interrupted = summary.get("interrupted", 0)
-    total = summary.get("total", 0)
-    pass_text = _color_word("pass", COLOR_GREEN, use_color)
-    details = []
+    skipped = summary.get("skipped", 0)
+    total = summary.get("total", run.get("planned_tests", 0))
+    if total <= 1:
+        return None
+
+    passed_text = _color_word("passed", COLOR_GREEN, use_color)
+    details = ["{} {}".format(passed, passed_text)]
     if failed:
-        fail_text = _color_word("fail", COLOR_RED, use_color)
-        details.append("{} {}".format(failed, fail_text))
+        failed_text = _color_word("failed", COLOR_RED, use_color)
+        details.append("{} {}".format(failed, failed_text))
     if interrupted:
-        details.append("{} interrupted".format(interrupted))
-    return ", ".join(["{}/{} {}".format(passed, total, pass_text)] + details)
+        interrupted_text = _color_word("interrupted", COLOR_YELLOW, use_color)
+        details.append("{} {}".format(interrupted, interrupted_text))
+    if skipped:
+        details.append("{} skipped".format(skipped))
+    return "[tests: {}]".format(" | ".join(details))
 
 
 def _resolve_use_color(use_color):
@@ -321,7 +451,44 @@ def _color_status(status, use_color):
     return status
 
 
-def format_history(project_dir, count, use_color=None):
+def _format_duration(duration_s):
+    duration_s = _duration_seconds(duration_s)
+    if duration_s is None:
+        return "-"
+    total_seconds = int(duration_s)
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    seconds = total_seconds % 60
+    return "{:02d}:{:02d}:{:02d}".format(hours, minutes, seconds)
+
+
+def _format_timing(run):
+    timing = run.get("timing", {})
+    if timing.get("compile_reused"):
+        compile_duration = "reused"
+    else:
+        compile_duration = _format_duration(timing.get("compile_elapsed_s"))
+    simulate_duration = _format_duration(timing.get("simulate_elapsed_s"))
+    return "[compile {} | simulate {}]".format(compile_duration, simulate_duration)
+
+
+def _is_failed_history_run(run):
+    return (run.get("status") in ("FAILED", "COMPILE_FAILED")
+            or int(run.get("summary", {}).get("failed", 0) or 0) > 0)
+
+
+def _filter_history_runs(runs, bench=None, failed_only=False):
+    filtered = []
+    for run in runs:
+        if bench is not None and bench not in _collect_benches(run):
+            continue
+        if failed_only and not _is_failed_history_run(run):
+            continue
+        filtered.append(run)
+    return filtered
+
+
+def format_history(project_dir, count, use_color=None, bench=None, failed_only=False):
     use_color = _resolve_use_color(use_color)
     try:
         store = load_store(project_dir)
@@ -330,18 +497,24 @@ def format_history(project_dir, count, use_color=None):
     runs = store.get("runs", [])
     if not runs:
         return "No simmer history found."
+    runs = _filter_history_runs(runs, bench=bench, failed_only=failed_only)
+    if not runs:
+        return "No matching simmer history found."
 
     lines = []
     recent_runs = list(reversed(runs))[:count]
     for index, run in enumerate(recent_runs, start=1):
         if lines:
             lines.append("")
-        lines.append("[{}] {}  {}  {}".format(
-            index,
-            run.get("finished_at") or run.get("started_at") or "-",
+        heading = [
+            "[{}] {}".format(index, run.get("finished_at") or run.get("started_at") or "-"),
             _color_status(run.get("status", "-"), use_color),
-            _format_pass_summary(run, use_color=use_color),
-        ))
+        ]
+        test_summary = _format_test_summary(run, use_color=use_color)
+        if test_summary is not None:
+            heading.append(test_summary)
+        heading.append(_format_timing(run))
+        lines.append("  ".join(heading))
         lines.append("cmd:     {}".format(run.get("command") or "-"))
         lines.append("compile: {}".format(_select_compile_log(run)))
         lines.append("result:  {}".format(_select_result_log(run)))
@@ -351,5 +524,5 @@ def format_history(project_dir, count, use_color=None):
     return "\n".join(lines)
 
 
-def print_history(project_dir, count, use_color=None):
-    print(format_history(project_dir, count, use_color=use_color))
+def print_history(project_dir, count, use_color=None, bench=None, failed_only=False):
+    print(format_history(project_dir, count, use_color=use_color, bench=bench, failed_only=failed_only))

--- a/tests/args_parser_validation_test.py
+++ b/tests/args_parser_validation_test.py
@@ -35,6 +35,33 @@ class ArgsParserValidationTest(unittest.TestCase):
         self.assert_parse_error(["--uvm-max-quit-count", "-1"])
         self.assertEqual(0, parse_args(["--uvm-max-quit-count", "0"]).uvm_max_quit_count)
 
+    def test_history_filters_enable_default_history_query(self):
+        for option in ("--history-bench", "--his-bench"):
+            with self.subTest(option=option):
+                options = parse_args([option, "sys_tb"])
+                self.assertEqual(10, options.history)
+                self.assertEqual("sys_tb", options.history_bench)
+
+        for option in ("--history-fail", "--his-fail"):
+            with self.subTest(option=option):
+                options = parse_args([option])
+                self.assertEqual(10, options.history)
+                self.assertTrue(options.history_fail)
+
+    def test_history_filters_preserve_explicit_count_and_combine(self):
+        options = parse_args(["--his", "20", "--his-bench", "sys_tb", "--his-fail"])
+
+        self.assertEqual(20, options.history)
+        self.assertEqual("sys_tb", options.history_bench)
+        self.assertTrue(options.history_fail)
+
+    def test_history_queries_reject_test_selection(self):
+        self.assert_parse_error(["--his", "-t", "sys_tb:test"])
+        self.assert_parse_error(["--his-bench", "sys_tb", "-t", "sys_tb:test"])
+
+    def test_history_bench_rejects_empty_name(self):
+        self.assert_parse_error(["--his-bench", ""])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/simmer_results_test.py
+++ b/tests/simmer_results_test.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import tempfile
 import threading
@@ -13,7 +14,11 @@ class SimmerResultsTest(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.project_dir = self.temp_dir.name
-        self.rcfg = SimpleNamespace(proj_dir=self.project_dir, regression_dir=self.project_dir)
+        self.rcfg = SimpleNamespace(
+            proj_dir=self.project_dir,
+            regression_dir=self.project_dir,
+            options=SimpleNamespace(no_compile=False),
+        )
 
     def tearDown(self):
         self.temp_dir.cleanup()
@@ -31,12 +36,29 @@ class SimmerResultsTest(unittest.TestCase):
         simmer_results.finalize_run(run)
         return run
 
+    def _save_history_run(self, bench, test, status):
+        run = simmer_results.create_run(["simmer", "-t", "{}:{}".format(bench, test)], self.rcfg, 1)
+        run["tests"] = [{
+            "bench": bench,
+            "test": test,
+            "status": status,
+            "simulation_started": True,
+            "cmp_log": "{}/cmp.log".format(bench),
+            "stdout_log": "{}/{}.log".format(bench, test),
+            "waves": {
+                "enabled": False
+            },
+        }]
+        simmer_results.finalize_run(run)
+        simmer_results.save_run(self.project_dir, run)
+        return run
+
     def test_run_ids_are_unique(self):
         self.assertNotEqual(self._completed_run()["run_id"], self._completed_run()["run_id"])
 
     def test_current_store_schema_records_interrupted_results(self):
-        self.assertEqual(3, simmer_results.SCHEMA_VERSION)
-        self.assertEqual(3, simmer_results.load_store(self.project_dir)["schema_version"])
+        self.assertEqual(4, simmer_results.SCHEMA_VERSION)
+        self.assertEqual(4, simmer_results.load_store(self.project_dir)["schema_version"])
 
         run = simmer_results.create_run(["simmer", "-t", "tb:test"], self.rcfg, 1)
         run["tests"] = [{"status": "INTERRUPTED"}]
@@ -45,7 +67,7 @@ class SimmerResultsTest(unittest.TestCase):
 
         self.assertEqual("INTERRUPTED", run["status"])
         store = simmer_results.load_store(self.project_dir)
-        self.assertEqual(3, store["schema_version"])
+        self.assertEqual(4, store["schema_version"])
         self.assertEqual(1, store["last_run"]["summary"]["interrupted"])
 
     def test_concurrent_saves_preserve_both_runs(self):
@@ -119,7 +141,7 @@ class SimmerResultsTest(unittest.TestCase):
         simmer_results.record_test_job(run, test_job)
 
         self.assertEqual(7, run["tests"][0]["duration_s"])
-        self.assertEqual(19, run["tests"][0]["wall_duration_s"])
+        self.assertEqual(19.8, run["tests"][0]["wall_duration_s"])
 
     def test_missing_simulator_duration_does_not_report_setup_time_as_simulation(self):
         run = simmer_results.create_run(["simmer", "-t", "tb:test"], self.rcfg, 1)
@@ -146,9 +168,12 @@ class SimmerResultsTest(unittest.TestCase):
         simmer_results.record_test_job(run, test_job)
 
         self.assertIsNone(run["tests"][0]["duration_s"])
-        self.assertEqual(19, run["tests"][0]["wall_duration_s"])
+        self.assertEqual(19.8, run["tests"][0]["wall_duration_s"])
+        self.assertFalse(run["tests"][0]["simulation_started"])
+        simmer_results.finalize_run(run)
+        self.assertFalse(simmer_results.save_run(self.project_dir, run))
 
-    def test_compile_failure_without_started_test_is_saved_and_shown(self):
+    def test_compile_failure_without_started_test_is_not_saved(self):
         run = simmer_results.create_run(["simmer", "-t", "tb:test"], self.rcfg, 1)
         run["compile"] = [{
             "bench": "tb",
@@ -159,12 +184,12 @@ class SimmerResultsTest(unittest.TestCase):
         }]
         simmer_results.finalize_run(run)
 
-        simmer_results.save_run(self.project_dir, run)
+        saved = simmer_results.save_run(self.project_dir, run)
 
         self.assertEqual("COMPILE_FAILED", run["status"])
-        history = simmer_results.format_history(self.project_dir, 10, use_color=False)
-        self.assertIn("COMPILE_FAILED", history)
-        self.assertIn("compile: cmp.log", history)
+        self.assertFalse(saved)
+        self.assertEqual([], simmer_results.load_store(self.project_dir)["runs"])
+        self.assertEqual("No simmer history found.", simmer_results.format_history(self.project_dir, 10))
 
     def test_compile_record_preserves_optional_performance_metrics(self):
         run = simmer_results.create_run(["simmer", "-t", "tb:test"], self.rcfg, 1)
@@ -184,11 +209,239 @@ class SimmerResultsTest(unittest.TestCase):
 
         simmer_results.record_compile_job(run, vcomp)
 
-        self.assertEqual(12, run["compile"][0]["duration_s"])
+        self.assertEqual(12.8, run["compile"][0]["duration_s"])
         self.assertEqual(4, run["compile"][0]["metrics"]["partcomp_jobs"])
 
         simmer_results.record_compile_job(run, vcomp, status="INTERRUPTED")
         self.assertEqual("INTERRUPTED", run["compile"][0]["status"])
+
+    def test_history_formats_single_run_elapsed_times(self):
+        started_at = datetime.datetime(2026, 8, 6, 10, 30, 0)
+        run = simmer_results.create_run(["simmer", "-t", "tb:test"], self.rcfg, 1)
+        vcomp = SimpleNamespace(
+            name="tb",
+            bazel_vcomp_target="//tb:tb",
+            jobstatus=SimpleNamespace(name="PASSED"),
+            job_dir="compile",
+            log_path="cmp.log",
+            duration_s=82.8,
+            compile_metrics={"compile_cache_hit": False},
+            error_message=None,
+            job_start_time=started_at,
+            job_stop_time=started_at + datetime.timedelta(seconds=82.8),
+        )
+        test_started_at = started_at + datetime.timedelta(seconds=90)
+        test_job = SimpleNamespace(
+            rcfg=SimpleNamespace(options=SimpleNamespace(waves=None)),
+            vcomper=vcomp,
+            name="test",
+            target="//tb:test",
+            iteration=1,
+            seed=7,
+            jobstatus=SimpleNamespace(name="PASSED"),
+            duration_s=140.9,
+            simulation_duration_s=138.4,
+            job_dir="sim",
+            _log_path="stdout.log",
+            error_message=None,
+            job_start_time=test_started_at,
+            job_stop_time=test_started_at + datetime.timedelta(seconds=140.9),
+        )
+
+        simmer_results.record_compile_job(run, vcomp)
+        simmer_results.record_test_job(run, test_job)
+        simmer_results.finalize_run(run)
+        simmer_results.save_run(self.project_dir, run)
+
+        self.assertEqual(82.8, run["timing"]["compile_elapsed_s"])
+        self.assertEqual(140.9, run["timing"]["simulate_elapsed_s"])
+        history = simmer_results.format_history(self.project_dir, 10, use_color=False)
+        heading = history.splitlines()[0]
+        self.assertNotIn("1/1", heading)
+        self.assertNotIn("[tests:", heading)
+        self.assertIn("[compile 00:01:22 | simulate 00:02:20]", history)
+
+    def test_regression_elapsed_time_unions_parallel_job_intervals(self):
+        started_at = datetime.datetime(2026, 8, 6, 10, 30, 0)
+        run = simmer_results.create_run(["simmer", "-t", "tb:*@2"], self.rcfg, 2)
+
+        def make_vcomp(name, start_s, stop_s):
+            return SimpleNamespace(
+                name=name,
+                bazel_vcomp_target="//{}:{}".format(name, name),
+                jobstatus=SimpleNamespace(name="PASSED"),
+                job_dir="compile/{}".format(name),
+                log_path="compile/{}/cmp.log".format(name),
+                duration_s=stop_s - start_s,
+                compile_metrics={"compile_cache_hit": False},
+                error_message=None,
+                job_start_time=started_at + datetime.timedelta(seconds=start_s),
+                job_stop_time=started_at + datetime.timedelta(seconds=stop_s),
+            )
+
+        def make_test(vcomp, name, iteration, start_s, stop_s):
+            return SimpleNamespace(
+                rcfg=SimpleNamespace(options=SimpleNamespace(waves=None)),
+                vcomper=vcomp,
+                name=name,
+                target="//tests:{}".format(name),
+                iteration=iteration,
+                seed=iteration,
+                jobstatus=SimpleNamespace(name="PASSED"),
+                duration_s=stop_s - start_s,
+                simulation_duration_s=stop_s - start_s,
+                job_dir="sim/{}".format(name),
+                _log_path="sim/{}/stdout.log".format(name),
+                error_message=None,
+                job_start_time=started_at + datetime.timedelta(seconds=start_s),
+                job_stop_time=started_at + datetime.timedelta(seconds=stop_s),
+            )
+
+        first_vcomp = make_vcomp("tb_a", 0, 10)
+        second_vcomp = make_vcomp("tb_b", 5, 15)
+        simmer_results.record_compile_job(run, first_vcomp)
+        simmer_results.record_compile_job(run, second_vcomp)
+        simmer_results.record_test_job(run, make_test(first_vcomp, "first", 1, 20, 50))
+        simmer_results.record_test_job(run, make_test(second_vcomp, "second", 2, 30, 70))
+
+        simmer_results.finalize_run(run)
+
+        self.assertEqual(15.0, run["timing"]["compile_elapsed_s"])
+        self.assertEqual(50.0, run["timing"]["simulate_elapsed_s"])
+
+    def test_history_labels_multi_test_result_counts(self):
+        run = simmer_results.create_run(["simmer", "-t", "tb:*@4"], self.rcfg, 4)
+        run["tests"] = [
+            {
+                "status": "PASSED",
+                "simulation_started": True,
+                "stdout_log": "pass.log",
+            },
+            {
+                "status": "FAILED",
+                "simulation_started": True,
+                "stdout_log": "fail.log",
+            },
+            {
+                "status": "INTERRUPTED",
+                "simulation_started": True,
+                "stdout_log": "interrupted.log",
+            },
+        ]
+
+        simmer_results.finalize_run(run, regression_log_path="regression.log")
+        simmer_results.save_run(self.project_dir, run)
+
+        history = simmer_results.format_history(self.project_dir, 10, use_color=False)
+        self.assertIn(
+            "FAILED  [tests: 1 passed | 1 failed | 1 interrupted | 1 skipped]  "
+            "[compile - | simulate -]",
+            history,
+        )
+
+    def test_history_marks_explicit_and_automatic_compile_reuse(self):
+        for explicit_reuse in (False, True):
+            with self.subTest(explicit_reuse=explicit_reuse), tempfile.TemporaryDirectory() as project_dir:
+                rcfg = SimpleNamespace(
+                    proj_dir=project_dir,
+                    regression_dir=project_dir,
+                    options=SimpleNamespace(no_compile=explicit_reuse),
+                )
+                run = simmer_results.create_run(["simmer", "-t", "tb:test"], rcfg, 1)
+                if not explicit_reuse:
+                    run["compile"] = [{
+                        "status": "PASSED",
+                        "metrics": {
+                            "compile_cache_hit": True
+                        },
+                        "cmp_log": "cmp.log",
+                    }]
+                run["tests"] = [{
+                    "status": "PASSED",
+                    "cmp_log": "cmp.log",
+                    "stdout_log": "stdout.log",
+                    "waves": {
+                        "enabled": False
+                    },
+                    "_elapsed_interval_s": [0.0, 43.9],
+                }]
+
+                simmer_results.finalize_run(run)
+                simmer_results.save_run(project_dir, run)
+
+                history = simmer_results.format_history(project_dir, 10, use_color=False)
+                self.assertIn("[compile reused | simulate 00:00:43]", history)
+
+    def test_history_without_timing_fields_remains_readable(self):
+        run = self._completed_run()
+        run.pop("timing")
+
+        simmer_results.save_run(self.project_dir, run)
+
+        history = simmer_results.format_history(self.project_dir, 10, use_color=False)
+        self.assertIn("[compile - | simulate -]", history)
+
+    def test_history_filters_by_bench_and_failure_before_limiting(self):
+        failed_a = self._save_history_run("tb_a", "failed_a", "FAILED")
+        self._save_history_run("tb_b", "failed_b", "FAILED")
+        self._save_history_run("tb_a", "passed_a", "PASSED")
+
+        self.assertEqual(["tb_a"], failed_a["benches"])
+
+        failed_history = simmer_results.format_history(
+            self.project_dir,
+            1,
+            use_color=False,
+            failed_only=True,
+        )
+        self.assertIn("tb_b:failed_b", failed_history)
+        self.assertNotIn("tb_a:passed_a", failed_history)
+        self.assertNotIn("tb_a:failed_a", failed_history)
+
+        bench_history = simmer_results.format_history(
+            self.project_dir,
+            10,
+            use_color=False,
+            bench="tb_a",
+        )
+        self.assertIn("tb_a:failed_a", bench_history)
+        self.assertIn("tb_a:passed_a", bench_history)
+        self.assertNotIn("tb_b:failed_b", bench_history)
+
+        combined_history = simmer_results.format_history(
+            self.project_dir,
+            10,
+            use_color=False,
+            bench="tb_a",
+            failed_only=True,
+        )
+        self.assertIn("tb_a:failed_a", combined_history)
+        self.assertNotIn("tb_a:passed_a", combined_history)
+        self.assertNotIn("tb_b:failed_b", combined_history)
+
+    def test_history_bench_filter_falls_back_for_old_records(self):
+        run = self._save_history_run("legacy_tb", "smoke", "PASSED")
+        store_path = Path(simmer_results.results_path(self.project_dir))
+        store = json.loads(store_path.read_text(encoding="utf-8"))
+        store["last_run"].pop("benches")
+        store["runs"][0].pop("benches")
+        store_path.write_text(json.dumps(store), encoding="utf-8")
+
+        history = simmer_results.format_history(self.project_dir, 10, use_color=False, bench="legacy_tb")
+
+        self.assertIn(run["command"], history)
+
+    def test_history_filters_report_no_matches(self):
+        self._save_history_run("tb", "passed", "PASSED")
+
+        self.assertEqual(
+            "No matching simmer history found.",
+            simmer_results.format_history(self.project_dir, 10, bench="missing"),
+        )
+        self.assertEqual(
+            "No matching simmer history found.",
+            simmer_results.format_history(self.project_dir, 10, failed_only=True),
+        )
 
     def test_multi_test_history_keeps_summary_and_one_representative_test(self):
         run = self._completed_run()

--- a/tests/simmer_runtime_hardening_test.py
+++ b/tests/simmer_runtime_hardening_test.py
@@ -104,14 +104,14 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
     def test_history_persistence_failure_is_fatal(self):
         rcfg = SimpleNamespace(
             proj_dir="/repo",
-            simmer_results_run={"run_id": "test"},
+            simmer_results_run={"run_id": "test", "tests": [{"status": "PASSED"}]},
             log=_FatalLog(),
         )
         with mock.patch("simmer.simmer_results.save_run", side_effect=OSError("disk full")), \
              self.assertRaisesRegex(SystemExit, "Failed to write simmer results"):
             simmer.persist_simmer_results(rcfg)
 
-    def test_interrupted_run_cleans_backend_and_persists_failed_history(self):
+    def test_interrupted_run_without_started_test_does_not_persist_history(self):
         with tempfile.TemporaryDirectory() as project_dir:
             run = {
                 "planned_tests": 1,
@@ -132,12 +132,12 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
             simulator.cleanup_shared_runtime_artifacts.assert_called_once()
             self.assertEqual("FAILED", run["status"])
             self.assertIsNotNone(run["finished_at"])
-            save_run.assert_called_once_with(project_dir, run)
+            save_run.assert_not_called()
 
     def test_interrupted_history_persistence_failure_is_nonfatal(self):
         run = {
             "planned_tests": 1,
-            "tests": [],
+            "tests": [{"status": "INTERRUPTED"}],
             "compile": [],
             "launch_failures": [],
         }
@@ -190,8 +190,8 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
         test_job.seed = 7
         test_job.job_dir = "/sim"
         test_job._log_path = "/sim/stdout.log"
-        test_job.job_start_time = None
-        test_job.job_stop_time = None
+        test_job.job_start_time = datetime.datetime.now() - datetime.timedelta(seconds=2)
+        test_job.job_stop_time = datetime.datetime.now()
         test_job.error_message = None
         test_job._jobstatus = simmer.JobStatus.NOT_STARTED
         manager = SimpleNamespace(interrupted_jobs=(test_job, ))
@@ -203,7 +203,7 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
         self.assertEqual(1, run["summary"]["interrupted"])
         self.assertEqual(1, run["summary"]["skipped"])
 
-    def test_interrupted_compile_is_recorded_in_history(self):
+    def test_interrupted_compile_without_started_test_is_not_persisted(self):
         run = {
             "planned_tests": 1,
             "tests": [],
@@ -225,10 +225,11 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
         vcomp._jobstatus = simmer.JobStatus.NOT_STARTED
         manager = SimpleNamespace(interrupted_jobs=(vcomp, ))
 
-        with mock.patch("simmer.simmer_results.save_run"):
+        with mock.patch("simmer.simmer_results.save_run") as save_run:
             simmer.finalize_interrupted_run(rcfg, mock.Mock(), {"//tb:tb": vcomp}, jm=manager)
 
         self.assertEqual("INTERRUPTED", run["compile"][0]["status"])
+        save_run.assert_not_called()
 
     def test_interrupt_cleanup_temporarily_ignores_additional_sigint(self):
         previous_handler = object()
@@ -248,8 +249,8 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
         for interrupted_phase in ("backend", "coverage", "report", "cleanup"):
             with self.subTest(interrupted_phase=interrupted_phase), tempfile.TemporaryDirectory() as project_dir:
                 run = {
-                    "planned_tests": 0,
-                    "tests": [],
+                    "planned_tests": 1,
+                    "tests": [{"status": "PASSED"}],
                     "compile": [],
                     "launch_failures": [],
                 }
@@ -429,8 +430,8 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
         test_job.iteration = 1
         test_job.job_dir = None
         test_job._log_path = None
-        test_job.job_start_time = None
-        test_job.job_stop_time = None
+        test_job.job_start_time = datetime.datetime.now() - datetime.timedelta(seconds=2)
+        test_job.job_stop_time = datetime.datetime.now()
         test_job.error_message = None
         test_job._jobstatus = simmer.JobStatus.NOT_STARTED
         manager = SimpleNamespace(interrupted_jobs=(test_job, ))

--- a/tests/simmer_runtime_hardening_test.py
+++ b/tests/simmer_runtime_hardening_test.py
@@ -104,7 +104,12 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
     def test_history_persistence_failure_is_fatal(self):
         rcfg = SimpleNamespace(
             proj_dir="/repo",
-            simmer_results_run={"run_id": "test", "tests": [{"status": "PASSED"}]},
+            simmer_results_run={
+                "run_id": "test",
+                "tests": [{
+                    "status": "PASSED"
+                }]
+            },
             log=_FatalLog(),
         )
         with mock.patch("simmer.simmer_results.save_run", side_effect=OSError("disk full")), \
@@ -137,7 +142,9 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
     def test_interrupted_history_persistence_failure_is_nonfatal(self):
         run = {
             "planned_tests": 1,
-            "tests": [{"status": "INTERRUPTED"}],
+            "tests": [{
+                "status": "INTERRUPTED"
+            }],
             "compile": [],
             "launch_failures": [],
         }
@@ -250,7 +257,9 @@ class SimmerRuntimeHardeningTest(unittest.TestCase):
             with self.subTest(interrupted_phase=interrupted_phase), tempfile.TemporaryDirectory() as project_dir:
                 run = {
                     "planned_tests": 1,
-                    "tests": [{"status": "PASSED"}],
+                    "tests": [{
+                        "status": "PASSED"
+                    }],
                     "compile": [],
                     "launch_failures": [],
                 }


### PR DESCRIPTION
## Summary
- record compile and simulation elapsed time in `.simmer_results.json`
- simplify single-test history output and label regression case counts
- add `--history-bench`/`--his-bench` and `--history-fail`/`--his-fail` filters
- skip history persistence when no simulation starts
- preserve old history compatibility and document the new behavior

## Validation
- `python -m unittest tests.args_parser_validation_test tests.simmer_results_test` (30 tests passed)
- `git diff --check`

Full Bazel/runtime tests were not run locally because Bazel is unavailable and the local Python environment does not contain the repository's existing `jinja2` dependency.