### PR TITLE
Add simmer active status and scoped caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ interrupted-history persistence, `pause` to stop active process groups and preve
 to keep running, or `status/logs` to print active job directories and log paths. A paused regression can then be resumed
 or stopped. Non-interactive runs stop immediately so batch jobs and CI never wait for input.
 
+### Inspecting active runs
+
+Use `simmer --status` or its short alias `simmer --st` to print every active simmer run for the current project. The
+query exits before discovery and shows the reconstructed `bsub` command, LSF job/queue/host metadata, compile log, and
+the single-test result log or multi-test regression log. Multi-test runs show aggregate finished/active/queued counts
+without expanding individual cases. Active records are isolated under `.simmer/runs/` and removed when their owning
+process exits.
+
 Large VCS regressions continue to use the reusable two-step
 `verilog_dv_tb` + `simmer` flow. Bazel one-step DV and RTL unit tests support
 both Xcelium and VCS.
@@ -394,7 +402,9 @@ reporting, MSIE, Palladium, ICO, VSO.ai and CCEX.
 `--no-compile` reuse is rejected when source/runfile content, an external
 compile configuration, or the selected simulator tool environment changes.
 Completed and interrupted simulations remain visible through `simmer --history`;
-failures that prevent every test from starting are not recorded.
+failures that prevent every test from starting are not recorded. Local history
+is stored in `.simmer/results.json`; older project-root `.simmer_results.json`
+files migrate automatically.
 
 ### Python Dependencies
 rules_verilog uses the Python libraries listed in `requirements.txt`, but it

--- a/bin/BUILD
+++ b/bin/BUILD
@@ -53,6 +53,7 @@ py_binary(
         "//lib:seed_plan",
         "//lib:sim_artifacts",
         "//lib:simmer_results",
+        "//lib:simmer_state",
         "//lib/simulators",
     ],
 )

--- a/bin/args_parse/common.py
+++ b/bin/args_parse/common.py
@@ -253,6 +253,12 @@ def add_regression_arguments(parser):
         action='store_true',
         help='Show failed history only. Used alone, query the most recent 10 matching records.')
     regression_group.add_argument(
+        '--status',
+        '--st',
+        default=False,
+        action='store_true',
+        help='Print all active simmer runs in this project and exit without discovery, compilation, or simulation.')
+    regression_group.add_argument(
         '--no-stdout',
         default=False,
         action='store_true',
@@ -284,8 +290,9 @@ def add_flow_control_arguments(parser):
         '--no-compile',
         default=False,
         action="store_true",
-        help=('Skip simulator compilation and reuse the existing VCOMP executable/database. Simmer validates the '
-              'compile fingerprint and required artifacts before launching simulations.'))
+        help=('Skip simulator compilation and reuse the existing VCOMP executable/database. Matching scoped '
+              'discovery data is reused without Bazel when available; otherwise simmer refreshes discovery once. '
+              'Simmer validates the compile fingerprint and required artifacts before launching simulations.'))
     flow_control_group.add_argument(
         '--recompile',
         default=False,
@@ -302,8 +309,9 @@ def add_flow_control_arguments(parser):
         '--no-bazel',
         default=False,
         action='store_true',
-        help=('Skip Bazel build and reuse existing bazel-bin/runfiles outputs. Use only when BUILD files, generated '
-              'filelists, source dependencies, and rule inputs are unchanged; commonly paired with --no-compile.'))
+        help=('Require a matching scoped discovery cache and reuse existing bazel-bin/runfiles outputs without '
+              'running Bazel. Use only when BUILD files, generated filelists, source dependencies, and rule inputs '
+              'are unchanged. Explicit use makes a missing or stale cache an error.'))
     report_toggle_group = flow_control_group.add_mutually_exclusive_group()
     report_toggle_group.add_argument(
         '--report',

--- a/bin/args_parse/parser.py
+++ b/bin/args_parse/parser.py
@@ -115,6 +115,9 @@ def parse_args(argv):
     parser = create_parser()
 
     options = parser.parse_args(argv)
+    options.no_bazel_was_explicit = argument_explicitly_requested(argv, '--no-bazel')
+    if options.no_compile:
+        options.no_bazel = True
     if options.jobs is not None and options.jobs < 1:
         parser.error("--jobs must be a positive integer.")
     if options.quit_count < 1:
@@ -134,6 +137,10 @@ def parse_args(argv):
         parser.error("--history must be a positive integer.")
     if options.history is not None and options.tests:
         parser.error("History query options cannot be combined with -t/--tests.")
+    if options.status and options.history is not None:
+        parser.error("--status/--st cannot be combined with history query options.")
+    if options.status and options.tests:
+        parser.error("--status/--st cannot be combined with -t/--tests.")
     if options.timeout < 0:
         parser.error("--timeout must be non-negative (0 disables the timeout).")
     options.simulator_was_explicit = simulator_explicitly_requested(argv)

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -37,6 +37,7 @@ from lib import rv_utils
 from lib import seed_plan
 from lib import sim_artifacts
 from lib import simmer_results
+from lib import simmer_state
 from lib.runtime_options import (
     append_uvm_control_options,
     format_log_check_args,
@@ -1303,7 +1304,38 @@ def _wait_for_jobs(jm, rcfg):
                 raise
 
 
-def main(rcfg, options):
+def _active_run_snapshot(rcfg, vcomp_jobs, jm, total_tests, regression_log_path):
+    """Build a compact run-level snapshot without exposing multi-test details."""
+    scheduler = jm.status_snapshot()
+    active_jobs = set(scheduler["launching"] + scheduler["active"] + scheduler["finalizing"])
+    test_jobs = [job for icfgs, _ in rcfg.all_vcomp.values() for icfg in icfgs for job in icfg.jobs]
+    finished_tests = sum(1 for job in test_jobs if job.jobstatus.completed)
+    active_tests = sum(1 for job in test_jobs if job in active_jobs)
+    queued_tests = max(0, total_tests - finished_tests - active_tests)
+    simulation_started = bool(active_tests or finished_tests
+                              or any(getattr(job, "job_start_time", None) is not None for job in test_jobs))
+    if scheduler["paused"]:
+        status = "PAUSED"
+    elif simulation_started and not rcfg.options.no_run:
+        status = "RUNNING"
+    else:
+        status = "COMPILING"
+    result_log = None
+    if total_tests == 1:
+        result_log = next((getattr(job, "_log_path", None) for job in test_jobs
+                           if getattr(job, "_log_path", None)), None)
+    return {
+        "status": status,
+        "finished_tests": finished_tests,
+        "active_tests": active_tests,
+        "queued_tests": queued_tests,
+        "compile_logs": [job.log_path for job in vcomp_jobs.values()],
+        "result_log": result_log,
+        "regression_log": regression_log_path,
+    }
+
+
+def main(rcfg, options, active_run=None):
     """
     Parameters
     ----------
@@ -1401,12 +1433,28 @@ def main(rcfg, options):
         if options.seed is not None:
             rcfg.log.critical("--seed can only be used if a single test is run")
             sys.exit(1)
+    regression_log_path = None
+    if total_tests > 1 and not options.no_run:
+        regression_log_path = rv_utils.prepare_regression_log(rcfg)
+    if active_run is not None:
+        active_run.update(
+            regression_dir=rcfg.regression_dir,
+            status="COMPILING",
+            planned_tests=total_tests,
+            finished_tests=0,
+            active_tests=0,
+            queued_tests=total_tests,
+            compile_logs=[job.log_path for job in vcomp_jobs.values()],
+            regression_log=regression_log_path,
+        )
+
     rcfg.simmer_results_run = None
     if not options.no_run:
         rcfg.simmer_results_run = simmer_results.create_run(
             getattr(options, "simmer_argv", sys.argv),
             rcfg,
             total_tests,
+            run_context=active_run.history_context() if active_run is not None else None,
         )
 
     try:
@@ -1460,7 +1508,15 @@ def main(rcfg, options):
                 elif not dynamic_test_plan:
                     jm.add_job(test)
 
+        if active_run is not None:
+            active_run.start_watching(
+                lambda: _active_run_snapshot(rcfg, vcomp_jobs, jm, total_tests, regression_log_path))
         _wait_for_jobs(jm, rcfg)
+        if active_run is not None:
+            active_run.stop_watching()
+            final_state = _active_run_snapshot(rcfg, vcomp_jobs, jm, total_tests, regression_log_path)
+            final_state["status"] = "FINALIZING"
+            active_run.update(**final_state)
         jm.stop()
         if options.no_run:
             rcfg.log.info("run_test:main(): --no_run option selected, exiting")
@@ -1468,6 +1524,9 @@ def main(rcfg, options):
     except KeyboardInterrupt:
         with _IgnoreAdditionalInterrupts():
             log.info("Saw keyboard interrupt, attempting to shutdown jobs.")
+            if active_run is not None:
+                active_run.stop_watching()
+                active_run.update(status="STOPPING")
             shutdown_complete = True
             if jm is not None:
                 try:
@@ -1487,7 +1546,7 @@ def main(rcfg, options):
         raise SystemExit(130)
 
     workflow_finalize_failed = False
-    regression_log_path = None
+    regression_log_path = getattr(rcfg, "regression_log_path", regression_log_path)
     post_processing_complete = False
     post_processing_interrupted = False
     total_failures = 0
@@ -1636,12 +1695,19 @@ def finalize_interrupted_run(rcfg,
                 simmer_results.record_test_job(run, job, status="INTERRUPTED", simulation_started=True)
             elif isinstance(job, VCompJob):
                 simmer_results.record_compile_job(run, job, status="INTERRUPTED")
-    simmer_results.finalize_run(run, backend_finalize_failed=True)
+    simmer_results.finalize_run(
+        run,
+        regression_log_path=getattr(rcfg, "regression_log_path", None),
+        backend_finalize_failed=True,
+    )
     persist_simmer_results(rcfg, fatal=False)
 
 
 if __name__ == '__main__':
     options = parse_args(sys.argv[1:])
+    if options.status:
+        simmer_state.print_status(options.proj_dir)
+        sys.exit(0)
     if options.history is not None:
         history_use_color = True if options.use_color else None
         simmer_results.print_history(
@@ -1655,5 +1721,12 @@ if __name__ == '__main__':
     options.simmer_argv = sys.argv[:]
     verbosity = cmn_logging.DEBUG if options.tool_debug else cmn_logging.INFO
     log = cmn_logging.build_logger("sim", level=verbosity, use_color=options.use_color, filehandler="simmer.log")
-    rcfg = regression.RegressionConfig(options, log)
-    main(rcfg, options)
+    active_run = None
+    if not options.discovery_only:
+        active_run = simmer_state.ActiveRun(options.proj_dir, options.simmer_argv, logger=log)
+    try:
+        rcfg = regression.RegressionConfig(options, log)
+        main(rcfg, options, active_run=active_run)
+    finally:
+        if active_run is not None:
+            active_run.close()

--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -1322,8 +1322,8 @@ def _active_run_snapshot(rcfg, vcomp_jobs, jm, total_tests, regression_log_path)
         status = "COMPILING"
     result_log = None
     if total_tests == 1:
-        result_log = next((getattr(job, "_log_path", None) for job in test_jobs
-                           if getattr(job, "_log_path", None)), None)
+        result_log = next((getattr(job, "_log_path", None) for job in test_jobs if getattr(job, "_log_path", None)),
+                          None)
     return {
         "status": status,
         "finished_tests": finished_tests,

--- a/docs/simmer_vcs_xcelium.md
+++ b/docs/simmer_vcs_xcelium.md
@@ -158,6 +158,12 @@ compile configuration files and the resolved VCS/VSO tool identity and
 locations. It fails before simulation when the existing compile output does not
 match the current inputs.
 
+`--no-compile` reuses the matching bench-scoped discovery cache without Bazel
+by default. If that cache is missing or stale, simmer refreshes discovery once
+before validating the existing compile output. Add explicit `--no-bazel` when
+the invocation must not run Bazel at all; a missing or stale scoped cache is
+then an error.
+
 VCS compile logs can contain a GNU make future-mtime warning when an NFS
 timestamp is less than 100 ms ahead of the execution host. Simmer treats that
 specific small skew and its paired clock-skew summary as benign, including when
@@ -387,7 +393,7 @@ minimize cross-partition XMRs. Inspect `cmp.log` for `PC_SHARED`, `PC_RECOMPILE`
 and the `-pcmakeprof` timing table. Coverage and Verdi require the referenced
 partition database to remain available. With `--vcs-profile`, simmer also
 stores marker counts, selected partition mode/jobs, compile wall time and cache
-reuse state in the compile entry of `.simmer_results.json`.
+reuse state in the compile entry of `.simmer/results.json`.
 
 Start with automatic partitioning. If profiling shows that stable third-party
 code shares a partition with frequently changing project code, add a VCS
@@ -679,7 +685,8 @@ For quiet normal runs, avoid `--tool-debug`; it prints scheduler polling noise.
 
 - Keep the VCS VCOMP directory between runs; Partition Compile and `-Mupdate`
   reuse unchanged third-party partitions and incremental compile outputs.
-- Use `--no-compile --no-bazel` only after the existing `simv` has been validated.
+- Use explicit `--no-compile --no-bazel` only when both the scoped discovery
+  cache and existing `simv` have already been validated.
 - Keep stable third-party IP/VIP in separate Bazel libraries/filelists so a TB
   edit does not rewrite their generated inputs.
 - Use `--fgp N` for runtime threading only after profiling; simmer reduces the
@@ -764,11 +771,13 @@ seed and original simulator options. Run it directly from any directory. Set
 
 ## Saving disk space
 
-- Discovery metadata is cached under `.simmer/cache/` and can be deleted at any
-  time. The cache tracks BUILD-prefixed files, `.bzl`, MODULE/WORKSPACE and
-  Bazel configuration files (including `.bazelignore`) inside the main
-  workspace. External IP/VIP repositories are intentionally excluded; run
-  `bazel clean` after changing them.
+- Discovery metadata is cached as one JSON file per normalized bench query
+  under `.simmer/cache/discovery/` and can be deleted at any time. Running one
+  TB does not replace another TB's discovery data. Each cache file tracks
+  BUILD-prefixed files, `.bzl`, MODULE/WORKSPACE and Bazel configuration files
+  (including `.bazelignore`) inside the main workspace. External IP/VIP
+  repositories are intentionally excluded; run `bazel clean` after changing
+  them.
 - Cached discovery reuses existing test-config outputs, but normal compile
   runs still issue an incremental `bazel build` for each selected testbench.
   This refreshes runfiles and compile-input digests after Verilog source
@@ -780,17 +789,57 @@ seed and original simulator options. Run it directly from any directory. Set
   throughput regressions.
 - Reuse the VCS VCOMP directory instead of creating a new `--dir-suffix` for
   every run.
-- Keep `.simmer_results.json` and compact regression logs; archive only failed
+- Keep `.simmer/results.json` and compact regression logs; archive only failed
   logs and selected FSDB/coverage artifacts.
 - Use `bazel clean` for stale Bazel outputs. Reserve `bazel clean --expunge` for
   deliberate cache removal because the next build will be fully cold.
 
+## Active run status
+
+Query every active simmer run for the current project without running discovery or Bazel:
+
+```bash
+simmer --status
+simmer --st
+```
+
+The query prints oldest first so the newest run is closest to the prompt. Each entry includes a reproducible `bsub`
+command, LSF job ID/queue/execution host/submission host, the matching `bkill` command, and available log paths. A
+single test shows its `stdout.log`; a multi-test run shows only aggregate progress and its regression log, not every
+case. Normal simulation commands do not print or query other active runs.
+
+Shell aliases are expanded before simmer starts, so their original text is not available to Python. Simmer reconstructs
+an equivalent `bsub -I -q <queue> ...` command from LSF state and its own argument vector. A site wrapper that needs to
+preserve additional submission flags exactly can export the complete command through `SIMMER_SUBMIT_CMD`; the same
+value is retained by `--his`.
+
+```text
+[2] 2026-08-07 09:18:24  RUNNING  7/20 finished, 4 active, 9 queued | elapsed 01:24:17
+cmd:        bsub -I -q syn simmer.py -t 'usb_tb:*@20' --jobs 4
+lsf:        job 851247 | queue syn | host sh-cloud17 | submit login02 | bkill 851247
+compile:    /sim/usb_tb/cmp.log
+regression: /sim/regression_results/usb_tb_regression_20260807_091824.log
+
+----------------------------------------------------------------
+
+[1] 2026-08-07 10:42:11  RUNNING  1 active | elapsed 00:03:26
+cmd:        bsub -I -q syn simmer.py -t sys_tb:sys_spi_apb_test --waves
+lsf:        job 852106 | queue syn | host sh-cloud21 | submit login02 | bkill 852106
+compile:    /sim/sys_tb/cmp.log
+result:     /sim/sys_tb/sys_spi_apb_test/stdout.log
+```
+
+The implementation stores one small atomic JSON file per invocation under `.simmer/runs/`. It writes only when the
+aggregate scheduler state changes and removes the file at exit. `--status` verifies remote records against LSF and
+removes records for jobs that have completed. No additional Python package is required.
+
 ## Simulation history
 
-Normal simulation invocations are recorded in `.simmer_results.json` at the
-project root after at least one simulation starts. Compile or launch failures
-that prevent every test from starting are not recorded. The file is local run
-state and is intended for quick lookup of recent outputs.
+Normal simulation invocations are recorded in `.simmer/results.json` after at
+least one simulation starts. Compile or launch failures that prevent every test
+from starting are not recorded. The file is local run state and is intended for
+quick lookup of recent outputs. Existing project-root `.simmer_results.json`
+files are merged and migrated automatically on the first history query or save.
 
 Print the most recent 10 runs:
 
@@ -827,8 +876,14 @@ Filters are applied before the count, so this example returns the most recent
 query options cannot be combined with `-t`/`--tests`; a query with no matches
 prints `No matching simmer history found.`.
 
-Each entry includes the original `simmer` command, compile log, result log, and
-compile/simulation elapsed time on the first line. Parallel jobs are measured as
+The selected records are printed from oldest to newest so the latest result is
+closest to the terminal prompt. Recency numbers count down toward `[1]`, which
+always identifies the latest matching record. A horizontal line separates
+adjacent records; a single-record result has no separator.
+
+Each new LSF-backed entry includes a reproducible `bsub` plus `simmer` command,
+LSF location metadata, compile log, result log, and compile/simulation elapsed
+time on the first line. Parallel jobs are measured as
 the union of their active intervals rather than by summing every case. Compile
 reuse is shown as `compile reused`. For a single test with wave dumping enabled,
 the history also shows the generated `run_waves.sh` path. For multi-test
@@ -838,8 +893,17 @@ case log.
 Example:
 
 ```text
+[2] 2026-07-08 11:42:17  PASSED  [compile 00:02:48 | simulate 00:04:06]
+cmd:     bsub -I -q syn simmer -t sys_tb:sys_iod_sanity_test
+lsf:     job 851247 | queue syn | host sh-cloud17 | submit login02
+compile: /sim/sys_tb/cmp.log
+result:  /sim/sys_tb/sys_iod_sanity_test/stdout.log
+
+----------------------------------------------------------------
+
 [1] 2026-07-09 15:03:04  FAILED  [tests: 87 passed | 13 failed]  [compile 00:03:12 | simulate 00:38:41]
-cmd:     simmer -t sys_tb:*@10
+cmd:     bsub -I -q syn simmer -t 'sys_tb:*@10'
+lsf:     job 852106 | queue syn | host sh-cloud21 | submit login02
 compile: /sim/sys_tb/cmp.log
 result:  /sim/regression.log
 ```

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -74,4 +74,10 @@ py_library(
 py_library(
     name = "simmer_results",
     srcs = ["simmer_results.py"],
+    deps = [":simmer_state"],
+)
+
+py_library(
+    name = "simmer_state",
+    srcs = ["simmer_state.py"],
 )

--- a/lib/regression.py
+++ b/lib/regression.py
@@ -23,12 +23,14 @@ from lib import bazel_profile, rv_utils
 # that doesn't format, but more work than its worth
 LOGGER_INDENT = 8
 BENCHES_REL_DIR = os.environ.get('BENCHES_REL_DIR', 'benches')
-DISCOVERY_CACHE_FILES = (
+LEGACY_DISCOVERY_CACHE_FILES = (
     "all_vcomp.json",
     "tests_to_tags.json",
     "tests_to_simulator.json",
     "discovery_manifest.json",
 )
+DISCOVERY_CACHE_SCHEMA_VERSION = 1
+DISCOVERY_SCOPE_SCHEMA_VERSION = 1
 DISCOVERY_ROOT_FILES = {
     ".bazelignore",
     ".bazelrc",
@@ -96,8 +98,12 @@ class RegressionConfig():
             self._should_use_cached_discovery,
         )
         if not self.use_cached_discovery:
+            strict_no_bazel = self.options.no_bazel and getattr(self.options, "no_bazel_was_explicit", True)
+            if strict_no_bazel:
+                self.log.critical("Discovery cache for the requested bench scope is missing or stale. "
+                                  "Please rerun without --no-bazel.")
             if self.options.no_bazel:
-                self.log.critical("Discovery cache missing or stale. Please rerun without --no-bazel.")
+                self.log.debug("Matching discovery cache unavailable; refreshing Bazel metadata once")
             self._profile_step(
                 "test_discovery_all",
                 "bazel query/cquery/build test cfg metadata",
@@ -194,7 +200,7 @@ class RegressionConfig():
         """
         path = self._cache_path(j)
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        descriptor, temporary_path = tempfile.mkstemp(prefix=".{}-".format(j),
+        descriptor, temporary_path = tempfile.mkstemp(prefix=".{}-".format(os.path.basename(j)),
                                                       suffix=".tmp",
                                                       dir=os.path.dirname(path),
                                                       text=True)
@@ -228,6 +234,27 @@ class RegressionConfig():
     def _cache_path(self, filename):
         return os.path.join(self.proj_dir, ".simmer", "cache", filename)
 
+    def _discovery_scope(self):
+        return {
+            "schema_version": DISCOVERY_SCOPE_SCHEMA_VERSION,
+            "bench_query": self._build_vcomp_discovery_query(),
+            "allow_no_run": bool(self.options.allow_no_run),
+        }
+
+    def _discovery_scope_id(self):
+        encoded_scope = json.dumps(
+            self._discovery_scope(),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(encoded_scope).hexdigest()[:20]
+
+    def _discovery_cache_relative_path(self):
+        return os.path.join("discovery", "{}.json".format(self._discovery_scope_id()))
+
+    def _discovery_cache_path(self):
+        return self._cache_path(self._discovery_cache_relative_path())
+
     @contextmanager
     def _discovery_cache_lock(self, exclusive):
         """Lock complete discovery generations across supported POSIX processes."""
@@ -250,16 +277,90 @@ class RegressionConfig():
             finally:
                 fcntl.flock(lock_file, fcntl.LOCK_UN)
 
+    def _discovery_cache_payload(self, manifest):
+        return {
+            "schema_version": DISCOVERY_CACHE_SCHEMA_VERSION,
+            "scope": self._discovery_scope(),
+            "manifest": manifest,
+            "all_vcomp": self.all_vcomp,
+            "tests_to_tags": self.tests_to_tags,
+            "tests_to_simulator": self.tests_to_simulator,
+        }
+
     def _read_discovery_cache_locked(self):
+        with open(self._discovery_cache_path(), "r", encoding="utf-8") as filep:
+            payload = json.load(filep)
+        if not isinstance(payload, dict) or payload.get("schema_version") != DISCOVERY_CACHE_SCHEMA_VERSION:
+            raise ValueError("Unsupported discovery cache schema")
+        if payload.get("scope") != self._discovery_scope():
+            raise ValueError("Discovery cache scope mismatch")
+        generation = tuple(
+            payload.get(name) for name in ("all_vcomp", "tests_to_tags", "tests_to_simulator", "manifest"))
+        if any(not isinstance(item, dict) for item in generation):
+            raise ValueError("Invalid discovery cache payload")
+        return generation
+
+    def _have_legacy_discovery_cache(self):
+        return all(os.path.exists(self._cache_path(filename)) for filename in LEGACY_DISCOVERY_CACHE_FILES)
+
+    def _read_legacy_discovery_cache_locked(self):
         generation = []
-        for filename in DISCOVERY_CACHE_FILES:
+        for filename in LEGACY_DISCOVERY_CACHE_FILES:
             with open(self._cache_path(filename), "r", encoding="utf-8") as filep:
                 generation.append(json.load(filep))
+        if any(not isinstance(item, dict) for item in generation):
+            raise ValueError("Invalid legacy discovery cache payload")
         return tuple(generation)
 
-    def _load_discovery_cache_generation(self):
+    def _remove_legacy_discovery_cache_locked(self):
+        for filename in LEGACY_DISCOVERY_CACHE_FILES:
+            try:
+                os.remove(self._cache_path(filename))
+            except FileNotFoundError:
+                pass
+
+    @staticmethod
+    def _same_discovery_scope(left_manifest, right_manifest):
+        return all(left_manifest.get(name) == right_manifest.get(name) for name in ("discovery_query", "allow_no_run"))
+
+    def _migrate_legacy_discovery_cache_locked(self, current_manifest):
+        if not self._have_legacy_discovery_cache():
+            return None
+        generation = self._read_legacy_discovery_cache_locked()
+        if generation[3] != current_manifest:
+            return None
+        all_vcomp, tests_to_tags, tests_to_simulator, manifest = generation
+        payload = {
+            "schema_version": DISCOVERY_CACHE_SCHEMA_VERSION,
+            "scope": self._discovery_scope(),
+            "manifest": manifest,
+            "all_vcomp": all_vcomp,
+            "tests_to_tags": tests_to_tags,
+            "tests_to_simulator": tests_to_simulator,
+        }
+        self.dict_to_json(payload, self._discovery_cache_relative_path())
+        self._remove_legacy_discovery_cache_locked()
+        self.log.debug("Migrated discovery cache for scope %s", self._discovery_scope_id())
+        return generation
+
+    def _read_or_migrate_discovery_cache(self, current_manifest):
         with self._discovery_cache_lock(exclusive=False):
-            return self._read_discovery_cache_locked()
+            try:
+                return self._read_discovery_cache_locked()
+            except FileNotFoundError:
+                pass
+        with self._discovery_cache_lock(exclusive=True):
+            try:
+                return self._read_discovery_cache_locked()
+            except FileNotFoundError:
+                generation = self._migrate_legacy_discovery_cache_locked(current_manifest)
+                if generation is None:
+                    raise FileNotFoundError(self._discovery_cache_path())
+                return generation
+
+    def _load_discovery_cache_generation(self):
+        current_manifest = self._discovery_dependency_manifest()
+        return self._read_or_migrate_discovery_cache(current_manifest)
 
     def _publish_discovery_cache(self, manifest=None):
         """Publish all discovery payloads as one advisory-locked generation."""
@@ -267,13 +368,13 @@ class RegressionConfig():
             manifest = self._discovery_dependency_manifest()
         self._warn_if_discovery_uncacheable(manifest)
         with self._discovery_cache_lock(exclusive=True):
-            self.dict_to_json(self.all_vcomp, "all_vcomp.json")
-            self.dict_to_json(self.tests_to_tags, "tests_to_tags.json")
-            self.dict_to_json(self.tests_to_simulator, "tests_to_simulator.json")
-            self.dict_to_json(manifest, "discovery_manifest.json")
-
-    def _have_discovery_cache(self):
-        return all(os.path.exists(self._cache_path(filename)) for filename in DISCOVERY_CACHE_FILES)
+            self.dict_to_json(self._discovery_cache_payload(manifest), self._discovery_cache_relative_path())
+            try:
+                legacy_manifest = self._read_legacy_discovery_cache_locked()[3]
+            except (OSError, ValueError, json.JSONDecodeError):
+                legacy_manifest = None
+            if legacy_manifest is not None and self._same_discovery_scope(legacy_manifest, manifest):
+                self._remove_legacy_discovery_cache_locked()
 
     def _warn_if_discovery_uncacheable(self, manifest):
         reason = manifest.get("uncacheable_reason")
@@ -290,7 +391,11 @@ class RegressionConfig():
 
     @staticmethod
     def _manifest_relative_path(path, project_root):
-        return os.path.relpath(os.path.realpath(path), project_root).replace(os.sep, "/")
+        real_path = os.path.realpath(path)
+        try:
+            return os.path.relpath(real_path, project_root).replace(os.sep, "/")
+        except ValueError:
+            return real_path.replace(os.sep, "/")
 
     def _discovery_dependency_manifest(self):
         submodule_state = self._git_submodule_state()
@@ -365,9 +470,10 @@ class RegressionConfig():
 
     def _write_discovery_manifest(self):
         manifest = self._discovery_dependency_manifest()
-        self._warn_if_discovery_uncacheable(manifest)
-        with self._discovery_cache_lock(exclusive=True):
-            self.dict_to_json(manifest, "discovery_manifest.json")
+        self.all_vcomp = getattr(self, "all_vcomp", {})
+        self.tests_to_tags = getattr(self, "tests_to_tags", {})
+        self.tests_to_simulator = getattr(self, "tests_to_simulator", {})
+        self._publish_discovery_cache(manifest)
 
     def _iter_project_discovery_dependency_paths(self, submodule_state):
         indexed_result = subprocess.run(
@@ -443,16 +549,15 @@ class RegressionConfig():
         yield from project_paths
 
     def _discovery_cache_is_fresh(self):
+        if not os.path.exists(self._discovery_cache_path()) and not self._have_legacy_discovery_cache():
+            return False
+        current_manifest = self._discovery_dependency_manifest()
         try:
-            with self._discovery_cache_lock(exclusive=False):
-                if not self._have_discovery_cache():
-                    return False
-                _, _, _, cached_manifest = self._read_discovery_cache_locked()
-                if not cached_manifest.get("cacheable", True):
-                    self._warn_if_discovery_uncacheable(cached_manifest)
-                    return False
-                current_manifest = self._discovery_dependency_manifest()
+            _, _, _, cached_manifest = self._read_or_migrate_discovery_cache(current_manifest)
         except (OSError, ValueError, json.JSONDecodeError):
+            return False
+        if not cached_manifest.get("cacheable", True):
+            self._warn_if_discovery_uncacheable(cached_manifest)
             return False
         if cached_manifest != current_manifest:
             self.log.debug("Discovery cache dependency manifest changed")
@@ -460,18 +565,19 @@ class RegressionConfig():
         return True
 
     def _should_use_cached_discovery(self):
+        if not os.path.exists(self._discovery_cache_path()) and not self._have_legacy_discovery_cache():
+            return False
+        current_manifest = self._discovery_dependency_manifest()
         try:
-            with self._discovery_cache_lock(exclusive=False):
-                if not self._have_discovery_cache():
-                    return False
-                all_vcomp, tests_to_tags, tests_to_simulator, cached_manifest = self._read_discovery_cache_locked()
-                if not cached_manifest.get("cacheable", True):
-                    self._warn_if_discovery_uncacheable(cached_manifest)
-                    return False
-                if cached_manifest != self._discovery_dependency_manifest():
-                    self.log.debug("Discovery cache dependency manifest changed")
-                    return False
+            all_vcomp, tests_to_tags, tests_to_simulator, cached_manifest = self._read_or_migrate_discovery_cache(
+                current_manifest)
         except (OSError, ValueError, json.JSONDecodeError):
+            return False
+        if not cached_manifest.get("cacheable", True):
+            self._warn_if_discovery_uncacheable(cached_manifest)
+            return False
+        if cached_manifest != current_manifest:
+            self.log.debug("Discovery cache dependency manifest changed")
             return False
 
         self._cached_discovery = (all_vcomp, tests_to_tags, tests_to_simulator)

--- a/lib/rv_utils.py
+++ b/lib/rv_utils.py
@@ -80,6 +80,16 @@ def create_regression_log_file(rcfg):
     return log_file_path
 
 
+def prepare_regression_log(rcfg):
+    """Create one stable regression log path before multi-test execution starts."""
+    regression_log_path = getattr(rcfg, "regression_log_path", None)
+    if regression_log_path:
+        return regression_log_path
+    regression_log_path = create_regression_log_file(rcfg)
+    rcfg.regression_log_path = regression_log_path
+    return regression_log_path
+
+
 def print_summary(rcfg, vcomp_jobs, jm, trd):
     """
     Print a summary of regression results
@@ -93,7 +103,7 @@ def print_summary(rcfg, vcomp_jobs, jm, trd):
     total_tests = sum([icfg.target for _, (icfgs, _) in rcfg.all_vcomp.items() for icfg in icfgs])
     if total_tests > 1:
         if not rcfg.options.no_run:
-            regression_log_path = create_regression_log_file(rcfg)
+            regression_log_path = prepare_regression_log(rcfg)
     else:
         if rcfg.options.report:
             current_time = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")

--- a/lib/simmer_results.py
+++ b/lib/simmer_results.py
@@ -5,14 +5,18 @@ import datetime
 import json
 import math
 import os
-import shlex
 import sys
 import uuid
 from contextlib import contextmanager
 
-RESULTS_FILENAME = ".simmer_results.json"
-SCHEMA_VERSION = 4
+from lib import simmer_state
+
+RESULTS_DIRECTORY = ".simmer"
+RESULTS_FILENAME = "results.json"
+LEGACY_RESULTS_FILENAME = ".simmer_results.json"
+SCHEMA_VERSION = 5
 MAX_RUNS = 100
+HISTORY_SEPARATOR = "-" * 64
 COLOR_GREEN = "\033[0;32m"
 COLOR_RED = "\033[0;31m"
 COLOR_YELLOW = "\033[0;33m"
@@ -20,15 +24,15 @@ COLOR_NC = "\033[0m"
 
 
 def results_path(project_dir):
-    return os.path.join(project_dir, RESULTS_FILENAME)
+    return os.path.join(project_dir, RESULTS_DIRECTORY, RESULTS_FILENAME)
+
+
+def legacy_results_path(project_dir):
+    return os.path.join(project_dir, LEGACY_RESULTS_FILENAME)
 
 
 def format_command(argv):
-    if not argv:
-        return "simmer"
-    display_argv = list(argv)
-    display_argv[0] = os.path.basename(display_argv[0]) or display_argv[0]
-    return " ".join(shlex.quote(str(arg)) for arg in display_argv)
+    return simmer_state.format_command(argv)
 
 
 def _timestamp():
@@ -128,6 +132,7 @@ def _collect_benches(run):
 
 @contextmanager
 def _store_lock(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path + ".lock", "a+b") as lock:
         if os.name == "nt":
             import msvcrt
@@ -150,14 +155,17 @@ def _store_lock(path):
                 fcntl.flock(lock, fcntl.LOCK_UN)
 
 
-def create_run(argv, rcfg, planned_tests):
+def create_run(argv, rcfg, planned_tests, run_context=None):
     options = getattr(rcfg, "options", None)
+    run_context = run_context or {}
+    lsf = run_context.get("lsf") or simmer_state.capture_lsf_context()
     return {
-        "run_id": _run_id(),
-        "started_at": _timestamp(),
+        "run_id": run_context.get("run_id") or _run_id(),
+        "started_at": run_context.get("started_at") or _timestamp(),
         "finished_at": None,
-        "command": format_command(argv),
+        "command": run_context.get("command") or simmer_state.format_submission_command(argv, lsf=lsf),
         "argv": list(argv),
+        "lsf": lsf,
         "project_dir": rcfg.proj_dir,
         "regression_dir": rcfg.regression_dir,
         "planned_tests": planned_tests,
@@ -311,8 +319,7 @@ def _empty_store():
     }
 
 
-def load_store(project_dir):
-    path = results_path(project_dir)
+def _read_store(path):
     if not os.path.exists(path):
         return _empty_store()
     with open(path, "r", encoding="utf-8") as filep:
@@ -324,6 +331,90 @@ def load_store(project_dir):
     store.setdefault("last_run", None)
     store.setdefault("runs", [])
     return store
+
+
+def _write_store(path, store):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    temp_path = "{}.{}.{}.tmp".format(path, os.getpid(), uuid.uuid4().hex)
+    try:
+        with open(temp_path, "w", encoding="utf-8") as filep:
+            json.dump(store, filep, indent=2)
+            filep.write("\n")
+        os.replace(temp_path, path)
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+
+def _quarantine_store(path):
+    corrupt_path = "{}.corrupt.{}".format(path, datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f"))
+    os.replace(path, corrupt_path)
+    print("Warning: moved invalid simmer history to {}".format(corrupt_path), file=sys.stderr)
+    return corrupt_path
+
+
+def _merge_stores(legacy_store, current_store, max_runs=MAX_RUNS):
+    merged_runs = []
+    run_positions = {}
+    for run in legacy_store.get("runs", []) + current_store.get("runs", []):
+        run_id = run.get("run_id")
+        if run_id and run_id in run_positions:
+            merged_runs[run_positions[run_id]] = run
+            continue
+        if run_id:
+            run_positions[run_id] = len(merged_runs)
+        merged_runs.append(run)
+    merged_runs = [
+        run for _, run in sorted(
+            enumerate(merged_runs),
+            key=lambda item: (
+                item[1].get("finished_at") or item[1].get("started_at") or "",
+                item[0],
+            ),
+        )
+    ][-max_runs:]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "last_run": merged_runs[-1] if merged_runs else None,
+        "runs": merged_runs,
+    }
+
+
+def _migrate_legacy_store_locked(project_dir, path):
+    legacy_path = legacy_results_path(project_dir)
+    if not os.path.exists(legacy_path):
+        return
+    with _store_lock(legacy_path):
+        if not os.path.exists(legacy_path):
+            return
+        try:
+            legacy_store = _read_store(legacy_path)
+        except (json.JSONDecodeError, ValueError):
+            _quarantine_store(legacy_path)
+            return
+        current_store = _read_store(path)
+        _write_store(path, _merge_stores(legacy_store, current_store))
+        try:
+            os.remove(legacy_path)
+        except OSError:
+            return
+    try:
+        os.remove(legacy_path + ".lock")
+    except OSError:
+        pass
+
+
+def _load_store_locked(project_dir, path):
+    _migrate_legacy_store_locked(project_dir, path)
+    return _read_store(path)
+
+
+def load_store(project_dir):
+    path = results_path(project_dir)
+    if not os.path.exists(path) and not os.path.exists(legacy_results_path(project_dir)):
+        return _empty_store()
+    with _store_lock(path):
+        return _load_store_locked(project_dir, path)
 
 
 def should_save_run(run):
@@ -344,12 +435,10 @@ def save_run(project_dir, run, max_runs=MAX_RUNS):
     path = results_path(project_dir)
     with _store_lock(path):
         try:
-            store = load_store(project_dir)
+            store = _load_store_locked(project_dir, path)
         except (json.JSONDecodeError, ValueError):
-            corrupt_path = "{}.corrupt.{}".format(path, datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f"))
-            os.replace(path, corrupt_path)
-            print("Warning: moved invalid simmer history to {}".format(corrupt_path), file=sys.stderr)
-            store = _empty_store()
+            _quarantine_store(path)
+            store = _load_store_locked(project_dir, path)
         runs = [item for item in store.get("runs", []) if item.get("run_id") != stored_run.get("run_id")]
         runs.append(stored_run)
         store = {
@@ -357,15 +446,7 @@ def save_run(project_dir, run, max_runs=MAX_RUNS):
             "last_run": stored_run,
             "runs": runs[-max_runs:],
         }
-        temp_path = "{}.{}.{}.tmp".format(path, os.getpid(), uuid.uuid4().hex)
-        try:
-            with open(temp_path, "w", encoding="utf-8") as filep:
-                json.dump(store, filep, indent=2)
-                filep.write("\n")
-            os.replace(temp_path, path)
-        finally:
-            if os.path.exists(temp_path):
-                os.remove(temp_path)
+        _write_store(path, store)
     return True
 
 
@@ -495,11 +576,10 @@ def format_history(project_dir, count, use_color=None, bench=None, failed_only=F
     if not runs:
         return "No matching simmer history found."
 
-    lines = []
-    recent_runs = list(reversed(runs))[:count]
-    for index, run in enumerate(recent_runs, start=1):
-        if lines:
-            lines.append("")
+    entries = []
+    recent_runs = runs[-count:]
+    for index, run in zip(range(len(recent_runs), 0, -1), recent_runs):
+        lines = []
         heading = [
             "[{}] {}".format(index,
                              run.get("finished_at") or run.get("started_at") or "-"),
@@ -511,12 +591,16 @@ def format_history(project_dir, count, use_color=None, bench=None, failed_only=F
         heading.append(_format_timing(run))
         lines.append("  ".join(heading))
         lines.append("cmd:     {}".format(run.get("command") or "-"))
+        lsf_summary = simmer_state.format_lsf_summary(run.get("lsf"))
+        if lsf_summary:
+            lines.append("lsf:     {}".format(lsf_summary))
         lines.append("compile: {}".format(_select_compile_log(run)))
         lines.append("result:  {}".format(_select_result_log(run)))
         waves_script = _select_waves_script(run)
         if waves_script is not None:
             lines.append("waves:   {}".format(waves_script or "-"))
-    return "\n".join(lines)
+        entries.append("\n".join(lines))
+    return "\n\n{}\n\n".format(HISTORY_SEPARATOR).join(entries)
 
 
 def print_history(project_dir, count, use_color=None, bench=None, failed_only=False):

--- a/lib/simmer_state.py
+++ b/lib/simmer_state.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python
+"""Active simmer run registration and status display helpers."""
+
+import datetime
+import json
+import os
+import shlex
+import socket
+import subprocess
+import threading
+import time
+import uuid
+
+STATE_SCHEMA_VERSION = 1
+STATE_DIRECTORY = os.path.join(".simmer", "runs")
+STATUS_SEPARATOR = "-" * 64
+ACTIVE_LSF_STATES = {
+    "PEND",
+    "PROV",
+    "PSUSP",
+    "RUN",
+    "SSUSP",
+    "UNKWN",
+    "USUSP",
+    "WAIT",
+}
+
+
+def state_directory(project_dir):
+    return os.path.join(project_dir, STATE_DIRECTORY)
+
+
+def state_path(project_dir, run_id):
+    return os.path.join(state_directory(project_dir), "{}.json".format(run_id))
+
+
+def _timestamp(epoch_seconds=None):
+    when = datetime.datetime.fromtimestamp(epoch_seconds) if epoch_seconds is not None else datetime.datetime.now()
+    return when.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _display_argv(argv):
+    if not argv:
+        return ["simmer"]
+    display_argv = [str(argument) for argument in argv]
+    display_argv[0] = os.path.basename(display_argv[0]) or display_argv[0]
+    return display_argv
+
+
+def format_command(argv):
+    return " ".join(shlex.quote(argument) for argument in _display_argv(argv))
+
+
+def capture_lsf_context(environment=None, hostname=None, interactive=None):
+    environment = os.environ if environment is None else environment
+    hostname = hostname or socket.gethostname()
+    interactive = bool(os.isatty(0)) if interactive is None else bool(interactive)
+    job_id = str(environment.get("LSB_JOBID") or "").strip()
+    job_index = str(environment.get("LSB_JOBINDEX") or "").strip()
+    display_job_id = job_id
+    if job_id and job_index not in ("", "0"):
+        display_job_id = "{}[{}]".format(job_id, job_index)
+    return {
+        "job_id": job_id or None,
+        "job_index": job_index or None,
+        "display_job_id": display_job_id or None,
+        "queue": str(environment.get("LSB_QUEUE") or "").strip() or None,
+        "host": hostname,
+        "submit_host": str(environment.get("LSB_SUB_HOST") or "").strip() or None,
+        "interactive": interactive,
+    }
+
+
+def format_submission_command(argv, lsf=None, environment=None):
+    environment = os.environ if environment is None else environment
+    supplied_command = str(environment.get("SIMMER_SUBMIT_CMD") or "").strip()
+    if supplied_command:
+        return supplied_command
+    lsf = lsf or capture_lsf_context(environment=environment)
+    if not lsf.get("job_id"):
+        return format_command(argv)
+    command = ["bsub"]
+    if lsf.get("interactive"):
+        command.append("-I")
+    if lsf.get("queue"):
+        command.extend(["-q", lsf["queue"]])
+    command.extend(_display_argv(argv))
+    return " ".join(shlex.quote(argument) for argument in command)
+
+
+def format_lsf_summary(lsf, include_bkill=False):
+    if not isinstance(lsf, dict):
+        return None
+    job_id = lsf.get("display_job_id") or lsf.get("job_id")
+    if not job_id:
+        return None
+    parts = ["job {}".format(job_id)]
+    if lsf.get("queue"):
+        parts.append("queue {}".format(lsf["queue"]))
+    if lsf.get("host"):
+        parts.append("host {}".format(lsf["host"]))
+    if lsf.get("submit_host"):
+        parts.append("submit {}".format(lsf["submit_host"]))
+    if include_bkill:
+        parts.append("bkill {}".format(shlex.quote(str(job_id))))
+    return " | ".join(parts)
+
+
+def _linux_process_start_time(process_id):
+    try:
+        with open("/proc/{}/stat".format(process_id), "r", encoding="ascii") as filep:
+            return filep.read().rsplit(")", 1)[1].split()[19]
+    except (OSError, IndexError):
+        return None
+
+
+def _process_exists(process_id):
+    try:
+        os.kill(process_id, 0)
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _write_state(path, state):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    temporary_path = "{}.{}.{}.tmp".format(path, os.getpid(), uuid.uuid4().hex)
+    try:
+        with open(temporary_path, "w", encoding="utf-8") as filep:
+            json.dump(state, filep, indent=2)
+            filep.write("\n")
+        os.replace(temporary_path, path)
+    finally:
+        try:
+            os.remove(temporary_path)
+        except FileNotFoundError:
+            pass
+
+
+class ActiveRun:
+    """Own one active-run state file for the lifetime of a simmer process."""
+
+    def __init__(self,
+                 project_dir,
+                 argv,
+                 regression_dir=None,
+                 logger=None,
+                 environment=None,
+                 hostname=None,
+                 interactive=None,
+                 process_id=None,
+                 now=None):
+        self.project_dir = os.path.abspath(project_dir)
+        self.logger = logger
+        self.run_id = uuid.uuid4().hex
+        self._path = state_path(self.project_dir, self.run_id)
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._watch_thread = None
+        self._enabled = True
+        now = time.time() if now is None else float(now)
+        process_id = os.getpid() if process_id is None else int(process_id)
+        lsf = capture_lsf_context(environment=environment, hostname=hostname, interactive=interactive)
+        self._state = {
+            "schema_version": STATE_SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "started_at": _timestamp(now),
+            "started_at_epoch": now,
+            "updated_at": _timestamp(now),
+            "command": format_submission_command(argv, lsf=lsf, environment=environment),
+            "argv": list(argv),
+            "project_dir": self.project_dir,
+            "regression_dir": regression_dir,
+            "status": "DISCOVERING",
+            "planned_tests": 0,
+            "finished_tests": 0,
+            "active_tests": 0,
+            "queued_tests": 0,
+            "compile_logs": [],
+            "result_log": None,
+            "regression_log": None,
+            "lsf": lsf,
+            "process": {
+                "pid": process_id,
+                "host": lsf["host"],
+                "start_time": _linux_process_start_time(process_id),
+            },
+        }
+        self._publish()
+
+    @property
+    def path(self):
+        return self._path
+
+    def history_context(self):
+        with self._lock:
+            return {
+                "run_id": self._state["run_id"],
+                "started_at": self._state["started_at"],
+                "command": self._state["command"],
+                "lsf": dict(self._state["lsf"]),
+            }
+
+    def _warn(self, message, exc):
+        if self.logger is not None:
+            self.logger.warning(message, exc)
+
+    def _publish(self):
+        if not self._enabled:
+            return
+        try:
+            _write_state(self._path, self._state)
+        except OSError as exc:
+            self._enabled = False
+            self._warn("Could not update simmer active-run state: %s", exc)
+
+    def update(self, **changes):
+        with self._lock:
+            changed = False
+            for key, value in changes.items():
+                if self._state.get(key) != value:
+                    self._state[key] = value
+                    changed = True
+            if not changed:
+                return False
+            self._state["updated_at"] = _timestamp()
+            self._publish()
+            return True
+
+    def start_watching(self, snapshot_fn, interval_seconds=5.0):
+        self.stop_watching()
+        self._stop_event.clear()
+
+        def watch():
+            while not self._stop_event.is_set():
+                try:
+                    self.update(**snapshot_fn())
+                except Exception as exc: # Status reporting must never stop a simulation.
+                    self._warn("Could not refresh simmer active-run state: %s", exc)
+                self._stop_event.wait(interval_seconds)
+
+        self._watch_thread = threading.Thread(name="simmer_active_state", target=watch, daemon=True)
+        self._watch_thread.start()
+
+    def stop_watching(self):
+        self._stop_event.set()
+        watch_thread = self._watch_thread
+        if watch_thread is not None and threading.current_thread() is not watch_thread:
+            watch_thread.join(timeout=2)
+        self._watch_thread = None
+
+    def close(self):
+        self.stop_watching()
+        try:
+            os.remove(self._path)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            self._warn("Could not remove simmer active-run state: %s", exc)
+
+
+def _load_state_files(project_dir):
+    directory = state_directory(project_dir)
+    try:
+        entries = list(os.scandir(directory))
+    except FileNotFoundError:
+        return []
+    states = []
+    for entry in entries:
+        if not entry.is_file() or not entry.name.endswith(".json"):
+            continue
+        try:
+            with open(entry.path, "r", encoding="utf-8") as filep:
+                state = json.load(filep)
+            if not isinstance(state, dict) or not state.get("run_id"):
+                continue
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        states.append((entry.path, state))
+    return states
+
+
+def _local_state_is_active(state, hostname):
+    process = state.get("process", {})
+    if process.get("host") != hostname:
+        return None
+    process_id = process.get("pid")
+    if not isinstance(process_id, int) or process_id < 1 or not _process_exists(process_id):
+        return False
+    expected_start_time = process.get("start_time")
+    if expected_start_time is None:
+        return True
+    return _linux_process_start_time(process_id) == expected_start_time
+
+
+def _query_lsf_states(job_ids, runner=subprocess.run):
+    if not job_ids:
+        return {}
+    try:
+        result = runner(
+            ["bjobs", "-a", "-noheader", *job_ids],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    states = {}
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) >= 3:
+            states[fields[0]] = fields[2].upper()
+    if result.returncode != 0 and not states:
+        return None
+    return states
+
+
+def load_active_runs(project_dir, hostname=None, lsf_runner=subprocess.run):
+    hostname = hostname or socket.gethostname()
+    candidates = _load_state_files(project_dir)
+    active = []
+    remote_lsf_states = []
+    for path, state in candidates:
+        local_active = _local_state_is_active(state, hostname)
+        if local_active is True:
+            active.append((path, state))
+        elif local_active is False:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+        else:
+            job_id = state.get("lsf", {}).get("display_job_id")
+            if job_id:
+                remote_lsf_states.append((path, state, job_id))
+            else:
+                active.append((path, state))
+
+    lsf_states = _query_lsf_states([item[2] for item in remote_lsf_states], runner=lsf_runner)
+    for path, state, job_id in remote_lsf_states:
+        if lsf_states is None or lsf_states.get(job_id) in ACTIVE_LSF_STATES:
+            active.append((path, state))
+            continue
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    return [
+        state for _, state in sorted(
+            active,
+            key=lambda item: (item[1].get("started_at_epoch", 0), item[1].get("run_id", "")),
+        )
+    ]
+
+
+def _format_duration(duration_seconds):
+    duration_seconds = max(0, int(duration_seconds))
+    hours = duration_seconds // 3600
+    minutes = (duration_seconds % 3600) // 60
+    seconds = duration_seconds % 60
+    return "{:02d}:{:02d}:{:02d}".format(hours, minutes, seconds)
+
+
+def _format_heading(index, state, now):
+    status = state.get("status") or "RUNNING"
+    parts = ["[{}] {}".format(index, state.get("started_at") or "-"), status]
+    planned = int(state.get("planned_tests") or 0)
+    finished = int(state.get("finished_tests") or 0)
+    active = int(state.get("active_tests") or 0)
+    queued = int(state.get("queued_tests") or 0)
+    if status in ("RUNNING", "PAUSED"):
+        if planned > 1:
+            parts.append("{}/{} finished, {} active, {} queued".format(finished, planned, active, queued))
+        elif active:
+            parts.append("{} active".format(active))
+        elif planned == 1 and finished:
+            parts.append("1/1 finished")
+    elapsed = now - float(state.get("started_at_epoch") or now)
+    return "  ".join(parts) + " | elapsed {}".format(_format_duration(elapsed))
+
+
+def format_status(project_dir, now=None, hostname=None, lsf_runner=subprocess.run):
+    states = load_active_runs(project_dir, hostname=hostname, lsf_runner=lsf_runner)
+    if not states:
+        return "No active simmer runs."
+    now = time.time() if now is None else float(now)
+    entries = []
+    for index, state in zip(range(len(states), 0, -1), states):
+        lines = [_format_heading(index, state, now)]
+        lines.append("{:<12}{}".format("cmd:", state.get("command") or "-"))
+        lsf_summary = format_lsf_summary(state.get("lsf"), include_bkill=True)
+        if lsf_summary:
+            lines.append("{:<12}{}".format("lsf:", lsf_summary))
+        compile_logs = [path for path in state.get("compile_logs", []) if path]
+        for log_index, compile_log in enumerate(compile_logs):
+            label = "compile:" if log_index == 0 else ""
+            lines.append("{:<12}{}".format(label, compile_log))
+        if int(state.get("planned_tests") or 0) > 1:
+            if state.get("regression_log"):
+                lines.append("{:<12}{}".format("regression:", state["regression_log"]))
+        elif state.get("result_log"):
+            lines.append("{:<12}{}".format("result:", state["result_log"]))
+        entries.append("\n".join(lines))
+    return "\n\n{}\n\n".format(STATUS_SEPARATOR).join(entries)
+
+
+def print_status(project_dir):
+    print(format_status(project_dir))

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -159,6 +159,13 @@ py_test(
 )
 
 py_test(
+    name = "simmer_state_test",
+    timeout = "short",
+    srcs = ["simmer_state_test.py"],
+    deps = ["//lib:simmer_state"],
+)
+
+py_test(
     name = "simmer_runtime_hardening_test",
     timeout = "short",
     srcs = ["simmer_runtime_hardening_test.py"],
@@ -177,6 +184,7 @@ py_test(
         "//lib:seed_plan",
         "//lib:sim_artifacts",
         "//lib:simmer_results",
+        "//lib:simmer_state",
         "//lib/simulators",
     ],
 )

--- a/tests/args_parser_validation_test.py
+++ b/tests/args_parser_validation_test.py
@@ -62,6 +62,27 @@ class ArgsParserValidationTest(unittest.TestCase):
     def test_history_bench_rejects_empty_name(self):
         self.assert_parse_error(["--his-bench", ""])
 
+    def test_status_query_supports_long_and_short_names(self):
+        self.assertTrue(parse_args(["--status"]).status)
+        self.assertTrue(parse_args(["--st"]).status)
+
+    def test_status_query_rejects_history_and_test_selection(self):
+        self.assert_parse_error(["--status", "--his"])
+        self.assert_parse_error(["--st", "-t", "sys_tb:test"])
+
+    def test_no_compile_reuses_bazel_outputs_by_default(self):
+        options = parse_args(["--no-compile"])
+
+        self.assertTrue(options.no_compile)
+        self.assertTrue(options.no_bazel)
+        self.assertFalse(options.no_bazel_was_explicit)
+
+    def test_explicit_no_bazel_is_tracked(self):
+        options = parse_args(["--no-compile", "--no-bazel"])
+
+        self.assertTrue(options.no_bazel)
+        self.assertTrue(options.no_bazel_was_explicit)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/regression_discovery_test.py
+++ b/tests/regression_discovery_test.py
@@ -48,18 +48,26 @@ def _cache_config_for_process(project_dir):
     config = RegressionConfig.__new__(RegressionConfig)
     config.proj_dir = project_dir
     config.log = _Log()
+    config.options = SimpleNamespace(
+        tests=[SimpleNamespace(btiglob="soc_tb:*", tag=set(), ntag=set())],
+        allow_no_run=False,
+    )
+    config.all_vcomp = {}
+    config.tests_to_tags = {}
+    config.tests_to_simulator = {}
     return config
 
 
 def _write_partial_cache_generation(project_dir, ready, release):
     config = _cache_config_for_process(project_dir)
     payload = {"generation": "new"}
+    config.all_vcomp = payload
+    config.tests_to_tags = payload
+    config.tests_to_simulator = payload
     with config._discovery_cache_lock(exclusive=True):
-        config.dict_to_json(payload, "all_vcomp.json")
+        config.dict_to_json(config._discovery_cache_payload(payload), config._discovery_cache_relative_path())
         ready.set()
         release.wait(5.0)
-        for filename in ("tests_to_tags.json", "tests_to_simulator.json", "discovery_manifest.json"):
-            config.dict_to_json(payload, filename)
 
 
 def _read_cache_generation(project_dir, result_queue):
@@ -93,7 +101,14 @@ class RegressionDiscoveryTest(unittest.TestCase):
         config.proj_dir = str(proj_dir)
         config.max_bench_name_length = 20
         config.max_test_name_length = 20
+        config.all_vcomp = {}
+        config.tests_to_tags = {}
+        config.tests_to_simulator = {}
         return config
+
+    @staticmethod
+    def _cache_payload(config):
+        return json.loads(Path(config._discovery_cache_path()).read_text(encoding="utf-8"))
 
     def test_cache_manifest_tracks_content_changes_and_deleted_files(self):
         proj_dir = Path(tempfile.mkdtemp())
@@ -135,8 +150,10 @@ class RegressionDiscoveryTest(unittest.TestCase):
         project_dir = tempfile.mkdtemp()
         config = self._config(Path(project_dir))
         old_payload = {"generation": "old"}
-        for filename in ("all_vcomp.json", "tests_to_tags.json", "tests_to_simulator.json", "discovery_manifest.json"):
-            config.dict_to_json(old_payload, filename)
+        config.all_vcomp = old_payload
+        config.tests_to_tags = old_payload
+        config.tests_to_simulator = old_payload
+        config.dict_to_json(config._discovery_cache_payload(old_payload), config._discovery_cache_relative_path())
 
         context = multiprocessing.get_context("fork")
         ready = context.Event()
@@ -244,7 +261,7 @@ class RegressionDiscoveryTest(unittest.TestCase):
             (cache_dir / filename).write_text("{}", encoding="utf-8")
 
         config._write_discovery_manifest()
-        manifest = json.loads((cache_dir / "discovery_manifest.json").read_text(encoding="utf-8"))
+        manifest = self._cache_payload(config)["manifest"]
         manifest_paths = {entry["path"] for entry in manifest["files"]}
         canonical_project_dir = os.path.realpath(project_dir)
         build_relative_path = os.path.relpath(os.path.realpath(build_file), canonical_project_dir).replace(os.sep, "/")
@@ -330,7 +347,7 @@ class RegressionDiscoveryTest(unittest.TestCase):
             (cache_dir / filename).write_text("{}", encoding="utf-8")
 
         config._write_discovery_manifest()
-        manifest = json.loads((cache_dir / "discovery_manifest.json").read_text(encoding="utf-8"))
+        manifest = self._cache_payload(config)["manifest"]
         manifest_paths = {entry["path"] for entry in manifest["files"]}
         repository_bzl_path = os.path.relpath(os.path.realpath(repository_bzl),
                                               os.path.realpath(project_dir)).replace(os.sep, "/")
@@ -387,7 +404,7 @@ class RegressionDiscoveryTest(unittest.TestCase):
             (cache_dir / filename).write_text("{}", encoding="utf-8")
 
         config._write_discovery_manifest()
-        manifest = json.loads((cache_dir / "discovery_manifest.json").read_text(encoding="utf-8"))
+        manifest = self._cache_payload(config)["manifest"]
         self.assertTrue(manifest["cacheable"])
         self.assertNotIn("uncacheable_reason", manifest)
         self.assertTrue(config._discovery_cache_is_fresh())
@@ -426,9 +443,45 @@ class RegressionDiscoveryTest(unittest.TestCase):
     def test_no_bazel_rejects_stale_cache(self):
         config = self._config(Path(tempfile.mkdtemp()))
         config.options.no_bazel = True
-        config._discovery_cache_is_fresh = lambda: False
 
         self.assertFalse(config._should_use_cached_discovery())
+
+    def test_implicit_no_bazel_refreshes_missing_discovery_for_no_compile(self):
+        project_dir = Path(tempfile.mkdtemp())
+        options = self._options(project_dir)
+        options.no_compile = True
+        options.no_bazel = True
+        options.no_bazel_was_explicit = False
+        results_dir = project_dir / "results"
+        test_target = "//benches/soc_tb/tests:dma_single_transfer"
+
+        def discover(config):
+            config.all_vcomp = {"//benches/soc_tb:soc_tb": {test_target: 0}}
+            config.tests_to_tags = {test_target: []}
+            config.tests_to_simulator = {test_target: "VCS"}
+
+        with mock.patch("lib.regression.rv_utils.calc_simresults_location", return_value=str(results_dir)), \
+             mock.patch.object(RegressionConfig, "_should_use_cached_discovery", return_value=False), \
+             mock.patch.object(RegressionConfig, "test_discovery_all", autospec=True, side_effect=discover) as refresh:
+            config = RegressionConfig(options, _Log())
+
+        refresh.assert_called_once()
+        self.assertEqual({"//benches/soc_tb:soc_tb": {test_target: 1}}, config.all_vcomp)
+
+    def test_explicit_no_bazel_rejects_missing_scoped_cache(self):
+        project_dir = Path(tempfile.mkdtemp())
+        options = self._options(project_dir)
+        options.no_compile = True
+        options.no_bazel = True
+        options.no_bazel_was_explicit = True
+
+        with mock.patch("lib.regression.rv_utils.calc_simresults_location", return_value=str(project_dir / "results")), \
+             mock.patch.object(RegressionConfig, "_should_use_cached_discovery", return_value=False), \
+             mock.patch.object(RegressionConfig, "test_discovery_all") as refresh:
+            with self.assertRaisesRegex(AssertionError, "requested bench scope"):
+                RegressionConfig(options, _Log())
+
+        refresh.assert_not_called()
 
     def test_requested_bench_query_is_scoped(self):
         config = self._config(Path(tempfile.mkdtemp()))
@@ -452,6 +505,99 @@ class RegressionDiscoveryTest(unittest.TestCase):
         config.options.allow_no_run = True
 
         self.assertNotEqual(initial, config._discovery_dependency_manifest())
+
+    def test_discovery_cache_isolated_by_requested_bench_scope(self):
+        project_dir = Path(tempfile.mkdtemp())
+        soc_config = self._config(project_dir)
+        soc_config.all_vcomp = {"//benches/soc_tb:soc_tb": {}}
+        soc_config.tests_to_tags = {"//benches/soc_tb/tests:smoke": ["smoke"]}
+        soc_config.tests_to_simulator = {"//benches/soc_tb/tests:smoke": "VCS"}
+        soc_config._publish_discovery_cache()
+        soc_path = Path(soc_config._discovery_cache_path())
+
+        other_config = self._config(project_dir)
+        other_config.options.tests[0].btiglob = "other_tb:*"
+        other_config.all_vcomp = {"//benches/other_tb:other_tb": {}}
+        other_config.tests_to_tags = {"//benches/other_tb/tests:smoke": []}
+        other_config.tests_to_simulator = {"//benches/other_tb/tests:smoke": "XRUN"}
+        other_config._publish_discovery_cache()
+        other_path = Path(other_config._discovery_cache_path())
+
+        self.assertNotEqual(soc_path, other_path)
+        self.assertTrue(soc_path.exists())
+        self.assertTrue(other_path.exists())
+        self.assertTrue(soc_config._should_use_cached_discovery())
+        self.assertEqual(soc_config.all_vcomp, soc_config._cached_discovery[0])
+
+    def test_same_bench_test_globs_share_discovery_scope(self):
+        project_dir = Path(tempfile.mkdtemp())
+        first = self._config(project_dir)
+        second = self._config(project_dir)
+        second.options.tests[0].btiglob = "soc_tb:other_test@10"
+
+        self.assertEqual(first._discovery_scope(), second._discovery_scope())
+        self.assertEqual(first._discovery_cache_path(), second._discovery_cache_path())
+
+    def test_multi_bench_selector_order_does_not_change_scope(self):
+        project_dir = Path(tempfile.mkdtemp())
+        first = self._config(project_dir)
+        first.options.tests.append(SimpleNamespace(btiglob="other_tb:*", tag=set(), ntag=set()))
+        second = self._config(project_dir)
+        second.options.tests.insert(0, SimpleNamespace(btiglob="other_tb:*", tag=set(), ntag=set()))
+
+        self.assertEqual(first._discovery_scope(), second._discovery_scope())
+
+    def test_other_scope_publish_preserves_unmigrated_legacy_cache(self):
+        project_dir = Path(tempfile.mkdtemp())
+        legacy_config = self._config(project_dir)
+        legacy_manifest = {
+            "discovery_query": legacy_config._build_vcomp_discovery_query(),
+            "allow_no_run": False,
+        }
+        for filename, payload in {
+                "all_vcomp.json": {
+                    "//benches/soc_tb:soc_tb": {}
+                },
+                "tests_to_tags.json": {},
+                "tests_to_simulator.json": {},
+                "discovery_manifest.json": legacy_manifest,
+        }.items():
+            legacy_config.dict_to_json(payload, filename)
+
+        other_config = self._config(project_dir)
+        other_config.options.tests[0].btiglob = "other_tb:*"
+        other_manifest = {
+            "discovery_query": other_config._build_vcomp_discovery_query(),
+            "allow_no_run": False,
+        }
+        other_config._publish_discovery_cache(other_manifest)
+
+        for filename in ("all_vcomp.json", "tests_to_tags.json", "tests_to_simulator.json", "discovery_manifest.json"):
+            self.assertTrue(Path(other_config._cache_path(filename)).exists())
+
+    def test_legacy_discovery_generation_migrates_to_scoped_file(self):
+        project_dir = Path(tempfile.mkdtemp())
+        config = self._config(project_dir)
+        manifest = config._discovery_dependency_manifest()
+        legacy_payloads = {
+            "all_vcomp.json": {
+                "//benches/soc_tb:soc_tb": {}
+            },
+            "tests_to_tags.json": {
+                "//benches/soc_tb/tests:smoke": []
+            },
+            "tests_to_simulator.json": {
+                "//benches/soc_tb/tests:smoke": "VCS"
+            },
+            "discovery_manifest.json": manifest,
+        }
+        for filename, payload in legacy_payloads.items():
+            config.dict_to_json(payload, filename)
+
+        self.assertTrue(config._should_use_cached_discovery())
+        self.assertTrue(Path(config._discovery_cache_path()).exists())
+        for filename in legacy_payloads:
+            self.assertFalse(Path(config._cache_path(filename)).exists())
 
     def test_test_cfg_query_uses_rule_marker_for_wrapped_macros(self):
         config = self._config(Path(tempfile.mkdtemp()))
@@ -585,23 +731,11 @@ class RegressionDiscoveryTest(unittest.TestCase):
     def test_init_creates_deferred_messages_with_cached_discovery(self):
         proj_dir = Path(tempfile.mkdtemp())
         results_dir = proj_dir / "results"
-        cache_dir = proj_dir / ".simmer" / "cache"
-        cache_dir.mkdir(parents=True)
-        for filename, payload in {
-                "all_vcomp.json": {
-                    "//benches/soc_tb:soc_tb": {
-                        "//benches/soc_tb/tests:dma_single_transfer": 1
-                    }
-                },
-                "tests_to_tags.json": {
-                    "//benches/soc_tb/tests:dma_single_transfer": []
-                },
-                "tests_to_simulator.json": {
-                    "//benches/soc_tb/tests:dma_single_transfer": "VCS"
-                },
-        }.items():
-            (cache_dir / filename).write_text(json.dumps(payload), encoding="utf-8")
-        self._config(proj_dir)._write_discovery_manifest()
+        cached_config = self._config(proj_dir)
+        cached_config.all_vcomp = {"//benches/soc_tb:soc_tb": {"//benches/soc_tb/tests:dma_single_transfer": 1}}
+        cached_config.tests_to_tags = {"//benches/soc_tb/tests:dma_single_transfer": []}
+        cached_config.tests_to_simulator = {"//benches/soc_tb/tests:dma_single_transfer": "VCS"}
+        cached_config._publish_discovery_cache()
 
         options = self._options(proj_dir)
         options.no_bazel = True

--- a/tests/simmer_entrypoint_test.py
+++ b/tests/simmer_entrypoint_test.py
@@ -1,5 +1,7 @@
+import os
 import subprocess
 import sys
+import tempfile
 import unittest
 
 SIMMER = sys.argv.pop(1)
@@ -16,6 +18,19 @@ class SimmerEntrypointTest(unittest.TestCase):
         )
         self.assertIn("usage: simmer", result.stdout)
         self.assertIn("--simulator {VCS,XRUN}", result.stdout)
+
+    def test_status_exits_without_project_discovery(self):
+        with tempfile.TemporaryDirectory() as project_dir:
+            environment = dict(os.environ, PROJ_DIR=project_dir)
+            result = subprocess.run(
+                [SIMMER, "--st"],
+                env=environment,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual("No active simmer runs.", result.stdout.strip())
 
 
 if __name__ == "__main__":

--- a/tests/simmer_results_test.py
+++ b/tests/simmer_results_test.py
@@ -53,12 +53,24 @@ class SimmerResultsTest(unittest.TestCase):
         simmer_results.save_run(self.project_dir, run)
         return run
 
+    def _write_legacy_store(self, runs):
+        path = Path(simmer_results.legacy_results_path(self.project_dir))
+        path.write_text(
+            json.dumps({
+                "schema_version": simmer_results.SCHEMA_VERSION,
+                "last_run": runs[-1] if runs else None,
+                "runs": runs,
+            }),
+            encoding="utf-8",
+        )
+        return path
+
     def test_run_ids_are_unique(self):
         self.assertNotEqual(self._completed_run()["run_id"], self._completed_run()["run_id"])
 
     def test_current_store_schema_records_interrupted_results(self):
-        self.assertEqual(4, simmer_results.SCHEMA_VERSION)
-        self.assertEqual(4, simmer_results.load_store(self.project_dir)["schema_version"])
+        self.assertEqual(5, simmer_results.SCHEMA_VERSION)
+        self.assertEqual(5, simmer_results.load_store(self.project_dir)["schema_version"])
 
         run = simmer_results.create_run(["simmer", "-t", "tb:test"], self.rcfg, 1)
         run["tests"] = [{"status": "INTERRUPTED"}]
@@ -67,7 +79,7 @@ class SimmerResultsTest(unittest.TestCase):
 
         self.assertEqual("INTERRUPTED", run["status"])
         store = simmer_results.load_store(self.project_dir)
-        self.assertEqual(4, store["schema_version"])
+        self.assertEqual(5, store["schema_version"])
         self.assertEqual(1, store["last_run"]["summary"]["interrupted"])
 
     def test_concurrent_saves_preserve_both_runs(self):
@@ -91,6 +103,7 @@ class SimmerResultsTest(unittest.TestCase):
 
     def test_corrupt_history_is_reported_and_preserved(self):
         path = Path(simmer_results.results_path(self.project_dir))
+        path.parent.mkdir(parents=True)
         path.write_text("{broken", encoding="utf-8")
 
         self.assertIn("Unable to read simmer history", simmer_results.format_history(self.project_dir, 10))
@@ -100,6 +113,50 @@ class SimmerResultsTest(unittest.TestCase):
         self.assertEqual(1, len(backups))
         self.assertEqual("{broken", backups[0].read_text(encoding="utf-8"))
         self.assertEqual(1, len(json.loads(path.read_text(encoding="utf-8"))["runs"]))
+
+    def test_history_is_stored_under_simmer_directory(self):
+        simmer_results.save_run(self.project_dir, self._completed_run())
+
+        path = Path(simmer_results.results_path(self.project_dir))
+        self.assertEqual(Path(self.project_dir) / ".simmer" / "results.json", path)
+        self.assertTrue(path.exists())
+
+    def test_legacy_history_migrates_when_read(self):
+        run = self._completed_run()
+        legacy_path = self._write_legacy_store([run])
+
+        store = simmer_results.load_store(self.project_dir)
+
+        self.assertEqual([run["run_id"]], [item["run_id"] for item in store["runs"]])
+        self.assertTrue(Path(simmer_results.results_path(self.project_dir)).exists())
+        self.assertFalse(legacy_path.exists())
+
+    def test_legacy_and_current_history_merge_without_duplicate_runs(self):
+        older = self._completed_run()
+        older["started_at"] = "2026-08-01 10:00:00"
+        older["finished_at"] = "2026-08-01 10:01:00"
+        current = self._completed_run()
+        current["started_at"] = "2026-08-02 10:00:00"
+        current["finished_at"] = "2026-08-02 10:01:00"
+        simmer_results.save_run(self.project_dir, current)
+        duplicate = dict(current)
+        duplicate["command"] = "legacy duplicate"
+        self._write_legacy_store([older, duplicate])
+
+        store = simmer_results.load_store(self.project_dir)
+
+        self.assertEqual([older["run_id"], current["run_id"]], [run["run_id"] for run in store["runs"]])
+        self.assertEqual(current["command"], store["last_run"]["command"])
+
+    def test_corrupt_legacy_history_is_preserved_during_migration(self):
+        legacy_path = Path(simmer_results.legacy_results_path(self.project_dir))
+        legacy_path.write_text("{broken", encoding="utf-8")
+
+        self.assertEqual([], simmer_results.load_store(self.project_dir)["runs"])
+
+        backups = list(legacy_path.parent.glob(legacy_path.name + ".corrupt.*"))
+        self.assertEqual(1, len(backups))
+        self.assertEqual("{broken", backups[0].read_text(encoding="utf-8"))
 
     def test_backend_finalize_failure_takes_precedence_over_partial(self):
         run = self._completed_run()
@@ -339,6 +396,40 @@ class SimmerResultsTest(unittest.TestCase):
             history,
         )
 
+    def test_history_preserves_submission_command_and_lsf_location(self):
+        run = simmer_results.create_run(
+            ["simmer", "-t", "tb:test"],
+            self.rcfg,
+            1,
+            run_context={
+                "command": "bsub -I -q syn simmer -t tb:test",
+                "lsf": {
+                    "job_id": "851247",
+                    "display_job_id": "851247",
+                    "queue": "syn",
+                    "host": "sh-cloud17",
+                    "submit_host": "login02",
+                },
+            },
+        )
+        run["tests"] = [{
+            "status": "PASSED",
+            "simulation_started": True,
+            "cmp_log": "cmp.log",
+            "stdout_log": "stdout.log",
+            "waves": {
+                "enabled": False
+            },
+        }]
+        simmer_results.finalize_run(run)
+        simmer_results.save_run(self.project_dir, run)
+
+        history = simmer_results.format_history(self.project_dir, 10, use_color=False)
+
+        self.assertIn("cmd:     bsub -I -q syn simmer -t tb:test", history)
+        self.assertIn("lsf:     job 851247 | queue syn | host sh-cloud17 | submit login02", history)
+        self.assertNotIn("bkill", history)
+
     def test_history_marks_explicit_and_automatic_compile_reuse(self):
         for explicit_reuse in (False, True):
             with self.subTest(explicit_reuse=explicit_reuse), tempfile.TemporaryDirectory() as project_dir:
@@ -380,6 +471,30 @@ class SimmerResultsTest(unittest.TestCase):
 
         history = simmer_results.format_history(self.project_dir, 10, use_color=False)
         self.assertIn("[compile - | simulate -]", history)
+
+    def test_history_displays_latest_last_with_descending_recency_numbers(self):
+        self._save_history_run("tb", "oldest", "PASSED")
+        self._save_history_run("tb", "middle", "FAILED")
+        self._save_history_run("tb", "newest", "PASSED")
+
+        history = simmer_results.format_history(self.project_dir, 2, use_color=False)
+        entries = history.split("\n\n{}\n\n".format(simmer_results.HISTORY_SEPARATOR))
+
+        self.assertEqual(2, len(entries))
+        self.assertTrue(entries[0].startswith("[2] "))
+        self.assertIn("tb:middle", entries[0])
+        self.assertTrue(entries[1].startswith("[1] "))
+        self.assertIn("tb:newest", entries[1])
+        self.assertNotIn("tb:oldest", history)
+        self.assertEqual(1, history.count(simmer_results.HISTORY_SEPARATOR))
+
+    def test_single_history_entry_has_no_separator(self):
+        self._save_history_run("tb", "only", "PASSED")
+
+        history = simmer_results.format_history(self.project_dir, 10, use_color=False)
+
+        self.assertTrue(history.startswith("[1] "))
+        self.assertNotIn(simmer_results.HISTORY_SEPARATOR, history)
 
     def test_history_filters_by_bench_and_failure_before_limiting(self):
         failed_a = self._save_history_run("tb_a", "failed_a", "FAILED")

--- a/tests/simmer_runtime_hardening_test.py
+++ b/tests/simmer_runtime_hardening_test.py
@@ -21,7 +21,7 @@ if str(REPO_ROOT) not in sys.path:
 from args_parser import parse_args
 import simmer
 from lib import compile_cache
-from lib.job_lib import JobCancelledError
+from lib.job_lib import JobCancelledError, JobStatus
 
 
 def _replace_symlink_in_process(link_path, target_path, start, result_queue):
@@ -43,6 +43,35 @@ class _FatalLog:
 
 
 class SimmerRuntimeHardeningTest(unittest.TestCase):
+
+    def test_active_run_snapshot_aggregates_multi_test_state(self):
+        finished = mock.Mock(jobstatus=JobStatus.PASSED, job_start_time=datetime.datetime.now())
+        active = mock.Mock(jobstatus=JobStatus.NOT_STARTED, job_start_time=datetime.datetime.now())
+        queued = mock.Mock(jobstatus=JobStatus.NOT_STARTED, job_start_time=None)
+        rcfg = SimpleNamespace(
+            all_vcomp={"//tb:tb": ([SimpleNamespace(jobs=[finished, active, queued])], [])},
+            options=SimpleNamespace(no_run=False),
+        )
+        manager = mock.Mock()
+        manager.status_snapshot.return_value = {
+            "paused": False,
+            "queued": (queued, ),
+            "launching": (),
+            "active": (active, ),
+            "finalizing": (),
+            "done": (finished, ),
+            "skipped": (),
+        }
+        vcomp = mock.Mock(log_path="/sim/tb/cmp.log")
+
+        state = simmer._active_run_snapshot(rcfg, {"//tb:tb": vcomp}, manager, 3, "/sim/regression.log")
+
+        self.assertEqual("RUNNING", state["status"])
+        self.assertEqual(1, state["finished_tests"])
+        self.assertEqual(1, state["active_tests"])
+        self.assertEqual(1, state["queued_tests"])
+        self.assertEqual("/sim/regression.log", state["regression_log"])
+        self.assertIsNone(state["result_log"])
 
     def test_vcs_compile_reuse_miss_messages_explain_incremental_behavior(self):
         self.assertEqual(

--- a/tests/simmer_state_test.py
+++ b/tests/simmer_state_test.py
@@ -1,0 +1,164 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from lib import simmer_state
+
+
+class SimmerStateTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_dir = self.temp_dir.name
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def _lsf_environment(job_id="851247"):
+        return {
+            "LSB_JOBID": job_id,
+            "LSB_QUEUE": "syn",
+            "LSB_SUB_HOST": "login02",
+        }
+
+    def test_lsf_context_builds_reproducible_submission_command(self):
+        environment = self._lsf_environment()
+        context = simmer_state.capture_lsf_context(
+            environment=environment,
+            hostname="sh-cloud17",
+            interactive=True,
+        )
+
+        self.assertEqual(
+            "bsub -I -q syn simmer.py -t 'usb_tb:*@20' --jobs 4",
+            simmer_state.format_submission_command(
+                ["/tools/simmer.py", "-t", "usb_tb:*@20", "--jobs", "4"],
+                lsf=context,
+                environment=environment,
+            ),
+        )
+        self.assertEqual(
+            "job 851247 | queue syn | host sh-cloud17 | submit login02 | bkill 851247",
+            simmer_state.format_lsf_summary(context, include_bkill=True),
+        )
+
+    def test_explicit_submit_command_is_preserved(self):
+        environment = self._lsf_environment()
+        environment["SIMMER_SUBMIT_CMD"] = "bs simmer -t sys_tb:test --waves"
+
+        self.assertEqual(
+            environment["SIMMER_SUBMIT_CMD"],
+            simmer_state.format_submission_command(["simmer", "-t", "sys_tb:test"], environment=environment),
+        )
+
+    def test_status_lists_all_runs_oldest_first_and_latest_as_one(self):
+        first = simmer_state.ActiveRun(
+            self.project_dir,
+            ["simmer", "-t", "usb_tb:*@20"],
+            environment=self._lsf_environment("851247"),
+            hostname="local-host",
+            interactive=True,
+            now=1000,
+        )
+        second = simmer_state.ActiveRun(
+            self.project_dir,
+            ["simmer", "-t", "sys_tb:test"],
+            environment=self._lsf_environment("852106"),
+            hostname="local-host",
+            interactive=True,
+            now=2000,
+        )
+        try:
+            first.update(
+                status="RUNNING",
+                planned_tests=20,
+                finished_tests=7,
+                active_tests=4,
+                queued_tests=9,
+                compile_logs=["/results/usb_tb/cmp.log"],
+                regression_log="/results/usb_tb/regression.log",
+            )
+            second.update(
+                status="RUNNING",
+                planned_tests=1,
+                active_tests=1,
+                compile_logs=["/results/sys_tb/cmp.log"],
+                result_log="/results/sys_tb/stdout.log",
+            )
+
+            output = simmer_state.format_status(self.project_dir, now=3000, hostname="local-host")
+
+            self.assertLess(output.index("[2] "), output.index("[1] "))
+            self.assertLess(output.index("usb_tb:*@20"), output.index("sys_tb:test"))
+            self.assertIn("RUNNING  7/20 finished, 4 active, 9 queued | elapsed 00:33:20", output)
+            self.assertIn("regression: /results/usb_tb/regression.log", output)
+            self.assertIn("result:     /results/sys_tb/stdout.log", output)
+            self.assertNotIn("usb_sanity_test", output)
+            self.assertEqual(1, output.count(simmer_state.STATUS_SEPARATOR))
+        finally:
+            first.close()
+            second.close()
+
+    def test_close_removes_active_state(self):
+        active_run = simmer_state.ActiveRun(self.project_dir, ["simmer"])
+        path = Path(active_run.path)
+        self.assertTrue(path.exists())
+
+        active_run.close()
+
+        self.assertFalse(path.exists())
+        self.assertEqual("No active simmer runs.", simmer_state.format_status(self.project_dir))
+
+    def test_dead_local_process_state_is_removed(self):
+        active_run = simmer_state.ActiveRun(self.project_dir, ["simmer"], hostname="local-host")
+        path = Path(active_run.path)
+        state = json.loads(path.read_text(encoding="utf-8"))
+        state["process"]["pid"] = 999999999
+        path.write_text(json.dumps(state), encoding="utf-8")
+        active_run._enabled = False
+
+        self.assertEqual(
+            "No active simmer runs.",
+            simmer_state.format_status(self.project_dir, hostname="local-host"),
+        )
+        self.assertFalse(path.exists())
+
+    def test_remote_completed_lsf_job_state_is_removed(self):
+        active_run = simmer_state.ActiveRun(
+            self.project_dir,
+            ["simmer"],
+            environment=self._lsf_environment(),
+            hostname="compute17",
+        )
+        path = Path(active_run.path)
+
+        def completed_job(*_args, **_kwargs):
+            return SimpleNamespace(returncode=0, stdout="851247 user DONE syn login compute job now\n")
+
+        self.assertEqual(
+            [],
+            simmer_state.load_active_runs(
+                self.project_dir,
+                hostname="login02",
+                lsf_runner=completed_job,
+            ),
+        )
+        self.assertFalse(path.exists())
+
+    def test_state_writes_only_when_snapshot_changes(self):
+        active_run = simmer_state.ActiveRun(self.project_dir, ["simmer"])
+        try:
+            original_mtime = os.stat(active_run.path).st_mtime_ns
+            self.assertFalse(active_run.update(status="DISCOVERING"))
+            self.assertEqual(original_mtime, os.stat(active_run.path).st_mtime_ns)
+            self.assertTrue(active_run.update(status="COMPILING"))
+        finally:
+            active_run.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- isolate discovery caches by normalized bench query and preserve --no-compile / --no-bazel compatibility
- add simmer --status / --st active-run reporting with LSF command, job, host, and log details
- store history and cache state under .simmer and retain LSF submission metadata

## Validation
- 55 state/history/argument/docs/summary tests passed
- 36 discovery/docs tests passed (2 Windows skips)
- Python compile checks and git diff --check passed

## Local limitations
- The full Bazel/Jinja2/POSIX scheduler suite was not run on Windows because Bazel, YAPF, Jinja2, and POSIX signals are unavailable locally.